### PR TITLE
(CTH-3) Implement message schema validation

### DIFF
--- a/bootstrap.cfg
+++ b/bootstrap.cfg
@@ -1,3 +1,0 @@
-com.puppetlabs.cthun-web-service/hello-web-service
-com.puppetlabs.cthun-service/hello-service
-puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,8 @@
                  [compojure "1.1.8"]
                  [org.clojure/tools.logging "0.3.0"]
                  [puppetlabs/trapperkeeper ~tk-version]
+                 [cheshire "5.3.1"]
+                 [prismatic/schema "0.2.6"]
 
 		 ;; we need version 9.2.2
                  [org.eclipse.jetty/jetty-server "9.2.2.v20140723"

--- a/src/puppetlabs/cthun/validation.clj
+++ b/src/puppetlabs/cthun/validation.clj
@@ -1,0 +1,33 @@
+(ns puppetlabs.cthun.validation
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [cheshire.core :as cheshire]
+            [schema.core :as s]))
+
+(def ISO8601
+  "Schema validates if string conforms to ISO8601"
+  (s/pred kitchensink/datetime? 'datetime?))
+
+(def ClientMessage
+  "Defines the message format expected from a client"
+  {(s/required-key "version") s/Str
+   (s/required-key "id") s/Int
+   (s/required-key "endpoints") [s/Str]
+   (s/required-key "data_schema") s/Str
+   (s/required-key "sender") s/Str
+   (s/required-key "expires") ISO8601
+   (s/required-key "hops") [{s/Str ISO8601}]
+   (s/optional-key "data") {s/Str s/Str}})
+
+(defn check-schema
+  "Check if the JSON matches the schema"
+  [json]
+  (s/validate ClientMessage json))
+
+(defn validate-message
+  "Validate the structure of a message"
+  [message]
+  (let [json (try (cheshire/parse-string message)
+                  (catch Exception e false))]
+    (when json
+      (check-schema json))))

--- a/test/puppetlabs/cthun/validation_test.clj
+++ b/test/puppetlabs/cthun/validation_test.clj
@@ -1,0 +1,20 @@
+(ns puppetlabs.cthun.validation-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.cthun.validation :refer :all]))
+
+(deftest check-schema-test
+  (testing "it raises an exception when an invalid message is received"
+    (is (thrown? Exception (check-schema "invalid message"))))
+  (testing "it returns the json structure when a valid message is passed"
+    (let [json {"version" "1"
+                "id" 1234
+                "endpoints" ["mco://host2.example.com/cnc/01"]
+                "data_schema" "/location/to/a/schema"
+                "sender" "mco://host1.example.com/controller/01",
+                "expires"  "2014-07-14T11:51:03+00:00"
+                "hops" [{"hop1" "2014-07-14T11:51:03+00:00"}]}]
+      (is (= json (check-schema json))))))
+
+(deftest validate-message-test
+  (testing "it returns nil if message is invalid json"
+    (is (= nil (validate-message "foo :")))))


### PR DESCRIPTION
This commit adds validation checking to text messages received
from the websocket's onMessage(text) handler using Cheshire and
Prismatic Schema.

A message must be valid json and adhere to the schema defined in
the initial design doc under the "Message format" heading.
