### PR TITLE
Cth 4

### DIFF
--- a/src/puppetlabs/cthun/connection_states.clj
+++ b/src/puppetlabs/cthun/connection_states.clj
@@ -1,0 +1,122 @@
+(ns puppetlabs.cthun.connection-states
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.cthun.validation :as validation]
+            [puppetlabs.kitchensink.core :as ks]
+            [cheshire.core :as cheshire]
+            [ring.adapter.jetty9 :as jetty-adapter]))
+
+(def connection-map (atom {}))
+(def endpoint-map (atom {}))
+
+; TODO(ploubser): Some of the functions defined here don't feel
+; like they fit with the name you've currently got for the namespace.
+
+(defn- get-endpoint-string
+  "Create a new endpoint string"
+  [host type]
+  (str "cth://" host "/" type "/" (str (java.util.UUID/randomUUID))))
+
+(defn- new-socket
+  "Return a new, unconfigured connection map"
+  []
+  {:socket-type "undefined"
+   :status "connected"
+   :user "undefined"
+   :endpoint "undefined"
+   :created-at (ks/timestamp)})
+
+(defn- process-login-message
+  "Process a login message from a client"
+  [host ws message-body]
+  (log/info "Processing login message")
+  (when (validation/validate-login-data (:data message-body))
+    (log/info "Valid login message received")
+    (if (= (:status (get (get @connection-map host) ws)) "ready")
+      ;There has already been a login even on the websocket
+      (throw (Exception. (str "Received login attempt from host '" host "' on socket '"
+                         ws "' but already logged in at " (:create-at (get (get @connection-map host) ws))
+                         " as "
+                         (:user (get (get @connection-map host) ws))
+                         ". Ignoring")))
+      (let [data (:data message-body)
+            type (:type data)
+            user (:user data)
+            endpoint (get-endpoint-string host type)]
+        (swap! connection-map assoc-in [host ws]
+               (-> (assoc (new-socket) :socket-type type)
+                   (assoc :status "ready")
+                   (assoc :endpoint endpoint)
+                   (assoc :user user)))
+        (swap! endpoint-map assoc endpoint ws)
+        (log/info "Successfully logged in user: " user " of type: " type
+                  " on websocket: " ws)))))
+
+(defn- process-server-message
+  "Process a message directed at the middleware"
+  [host ws message-body]
+  (log/info "Procesesing server message")
+  ; We've only got one message type at the moment - login
+  ; More will be added as we add server functionality
+  ; To define a new message type add a schema to
+  ; puppetlabs.cthun.validation, check for it here and process it.
+  (let [data-schema (:data_schema message-body)]
+    (case data-schema
+      "http://puppetlabs.com/loginschema" (process-login-message host ws message-body)
+      (log/warn "Invalid server message type received: " data-schema))))
+
+
+(defn- process-client-message
+  "Process a message directed at a connected client"
+  [host ws message-body]
+  (map (fn [endpoint]
+  (doseq [endpoints (message-body "endpoints")]
+                (fn [endpoint]
+        (if (contains? @endpoint-map endpoint)
+          (jetty-adapter/send! (@endpoint-map endpoint) 
+                               (cheshire/generate-string message-body))
+          (println "Message directed at non existing endpoint: " endpoint
+                   ". Ignoring message.")))
+             (message-body "endpoints")))))
+
+(defn- logged-in?
+  "Determine if host/websocket combination has logged in"
+  [host ws]
+  (= (:status (get (get @connection-map host) ws)) "ready"))
+
+
+(defn- login-message?
+  "Return true if message is a login type message"
+  [message]
+  (and (= (get (:endpoints message) 0) "cth://server") 
+       (= (:data_schema message) "http://puppetlabs.com/loginschema")))
+
+(defn add-connection
+  "Add a connection to the connection state map"
+  [host ws]
+  (swap! connection-map assoc-in [host ws] (new-socket)))
+
+(defn remove-connection
+  "Remove a connection from the connection state map"
+  [host ws]
+  ; Remove the endpoint
+  (swap! endpoint-map dissoc (:endpoint (get ws (get host @connection-map)))
+  ; Remove the connection
+  (swap! connection-map update-in [host] dissoc ws))
+  (when (empty? (@connection-map host))
+    (swap! connection-map dissoc host)))
+
+(defn process-message
+  "Process an incoming message from a websocket"
+  [host ws message-body]
+  (log/info "processing incoming message")
+  ; Check if socket has been logged into
+  (if (logged-in? host ws)
+  ; check if this is a message directed at the middleware
+    (if (= (get (:endpoints message-body) 0) "cth://server")
+      (process-server-message host ws message-body)
+      (process-client-message host ws message-body))
+    (if (login-message? message-body)
+      (process-server-message host ws message-body)
+      (log/warn "Connection cannot accept messages until login message has been "
+                 "processed. Dropping message."))))
+

--- a/src/puppetlabs/cthun/validation.clj
+++ b/src/puppetlabs/cthun/validation.clj
@@ -1,23 +1,30 @@
 (ns puppetlabs.cthun.validation
   (:require [clojure.tools.logging :as log]
-            [puppetlabs.kitchensink.core :as kitchensink]
+            [puppetlabs.kitchensink.core :as ks]
             [cheshire.core :as cheshire]
             [schema.core :as s]))
 
 (def ISO8601
   "Schema validates if string conforms to ISO8601"
-  (s/pred kitchensink/datetime? 'datetime?))
+  (s/pred ks/datetime? 'datetime?))
 
+; Message types
 (def ClientMessage
   "Defines the message format expected from a client"
-  {(s/required-key "version") s/Str
-   (s/required-key "id") s/Int
-   (s/required-key "endpoints") [s/Str]
-   (s/required-key "data_schema") s/Str
-   (s/required-key "sender") s/Str
-   (s/required-key "expires") ISO8601
-   (s/required-key "hops") [{s/Str ISO8601}]
-   (s/optional-key "data") {s/Str s/Str}})
+  {(s/required-key :version) s/Str
+   (s/required-key :id) s/Int
+   (s/required-key :endpoints) [s/Str]
+   (s/required-key :data_schema) s/Str
+   (s/required-key :sender) s/Str
+   (s/required-key :expires) ISO8601
+   (s/required-key :hops) [{s/Keyword ISO8601}]
+   (s/optional-key :data) {s/Keyword s/Str}})
+
+; Server message data types
+(def LoginMessageData
+  "Defines the data field in a login message body"
+  {(s/required-key :type) s/Str
+   (s/required-key :user) s/Str})
 
 (defn check-schema
   "Check if the JSON matches the schema"
@@ -27,7 +34,13 @@
 (defn validate-message
   "Validate the structure of a message"
   [message]
-  (let [json (try (cheshire/parse-string message)
+  (let [json (try (cheshire/parse-string message true)
                   (catch Exception e false))]
     (when json
       (check-schema json))))
+
+
+(defn validate-login-data
+  "Validate the structure of a login message data field"
+  [data]
+  (s/validate LoginMessageData data))

--- a/src/puppetlabs/cthun_core.clj
+++ b/src/puppetlabs/cthun_core.clj
@@ -18,4 +18,4 @@
 (defn state
   "Return the service state"
   [caller]
-  (@websockets/websocket-state))
+  (log/info "Not yet implemented"))

--- a/test-resources/logback-dev.xml
+++ b/test-resources/logback-dev.xml
@@ -8,7 +8,7 @@
     <logger name="org.eclipse.jetty.server" level="warn"/>
     <logger name="org.eclipse.jetty.util.log" level="warn"/>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/test/puppetlabs/cthun/connection_states_test.clj
+++ b/test/puppetlabs/cthun/connection_states_test.clj
@@ -1,0 +1,107 @@
+(ns puppetlabs.cthun.connection-states-test
+  (require [clojure.test :refer :all]
+           [puppetlabs.cthun.connection-states :refer :all]
+           [puppetlabs.kitchensink.core :as ks]))
+
+
+; private symbols
+(def get-endpoint-string #'puppetlabs.cthun.connection-states/get-endpoint-string)
+(def new-socket #'puppetlabs.cthun.connection-states/new-socket)
+(def process-login-message #'puppetlabs.cthun.connection-states/process-login-message)
+(def process-server-message  #'puppetlabs.cthun.connection-states/process-server-message)
+(def logged-in?  #'puppetlabs.cthun.connection-states/logged-in?)
+(def login-message?  #'puppetlabs.cthun.connection-states/login-message?)
+
+(deftest get-endpoint-string-test
+  (testing "It creates a correct endpoint string"
+    (is (re-matches #"cth://localhost/controller/.*" (get-endpoint-string "localhost" "controller")))))
+
+(deftest new-socket-test
+  (testing "It returns a map that matches represents a new socket"
+    (let [socket (new-socket)]
+      (is (= (:socket-type socket) "undefined"))
+      (is (= (:status socket) "connected"))
+      (is (= (:user socket) "undefined"))
+      (is (= (:endpoint socket) "undefined"))
+      (is (not= nil (ks/datetime? (:created-at socket)))))))
+
+(deftest process-login-message-test
+  (with-redefs [puppetlabs.cthun.validation/validate-login-data (fn [data] true)]
+    (testing "It should perform a login"
+      (add-connection "ws" "localhost")
+      (process-login-message "localhost" 
+                             "ws"
+                               {:data {
+                                        :type "controller"
+                                        :user "testing"
+                                        }})
+      (let [connection (get (get @connection-map "localhost") "ws")]
+        (is (= (:socket-type connection) "controller"))
+        (is (= (:status connection) "ready"))
+        (is (= (:user connection) "testing"))
+        (is (re-matches #"cth://localhost/controller/.*" (:endpoint connection))))))
+
+
+  (testing "It does not allow a login to happen twice on the same socket"
+    (with-redefs [puppetlabs.cthun.validation/validate-login-data (fn [data] true)]
+      (add-connection "localhost" "ws")
+      (process-login-message "localhost" 
+                             "ws"
+                             {:data {
+                                     :type "controller"
+                                     :user "testing"
+                                     }}))
+      (is (thrown? Exception  (process-login-message "localhost" 
+                                                     "ws"
+                                                     {:data {
+                                                             :type "controller"
+                                                             :user "testing"
+                                                             }})))))
+
+(deftest process-server-message-test
+  (with-redefs [puppetlabs.cthun.connection-states/process-login-message (fn [host ws message-body] true)]
+    (testing "It should identify a login message from the data schema"
+      (is (= (process-server-message "localhost" "w" {:data_schema "http://puppetlabs.com/loginschema"}) true)))
+    (testing "It should not process an unkown type of server message"
+      (is (= (process-server-message "localhost" "w" {:data_schema "http://puppetlabs.com"}) nil)))))
+
+(deftest logged-in?-test
+    (testing "It returns true if the websocket is logged in"
+      (swap! connection-map assoc-in ["localhost" "ws"] {:status "ready"})
+      (is (= (logged-in? "localhost" "ws") true)))
+    (testing "It returns false if the websocket is not logged in"
+      (swap! connection-map assoc-in ["localhost" "ws"] {:status "connected"})))
+
+(deftest login-message?-test
+  (testing "It returns true when passed a login type messge"
+    (is (= (login-message? {:endpoints ["cth://server"] :data_schema "http://puppetlabs.com/loginschema"}))))
+  (testing "It returns false when passed a message of an unknown type"
+    (is (= (login-message? {:endpoints ["cth://otherserver"] :data_schema "http://puppetlabs.com/loginschema"})))))
+
+(deftest add-connection-test
+  (testing "It should add a connection to the connection map"
+    (add-connection "localhost" "ws")
+    (is (= (:status (get  (get @connection-map "localhost") "ws")) "connected"))))
+
+(deftest remove-connection-test
+  (testing "It should remove a connection from the connection map"
+    (add-connection "localhost" "ws")
+    (remove-connection "localhost" "ws")
+    (is (= (get @connection-map "localhost") nil))))
+
+(deftest process-message-test
+  (testing "It will ignore messages until the the client is logged in"
+    (is (= (process-message "localhost" "ws" {}) nil)))
+  (testing "It will process a login message if the client is not logged in"
+    (with-redefs [puppetlabs.cthun.connection-states/process-server-message (fn [host ws message-body] "login")
+                  puppetlabs.cthun.connection-states/login-message? (fn [message-body] true)]
+      (is (= (process-message "localhost" "ws" {}) "login"))))
+  (testing "It will process a client message"
+    (with-redefs [puppetlabs.cthun.connection-states/logged-in? (fn [host ws] true)
+                  puppetlabs.cthun.connection-states/process-client-message (fn [host ws message-body] "client")]
+      (is (= (process-message "localhost" "ws" {:endpoints ["cth://client1.com"]}) "client"))))
+  (testing "It will process a server message"
+    (with-redefs [puppetlabs.cthun.connection-states/logged-in? (fn [host ws] true)
+                  puppetlabs.cthun.connection-states/process-server-message (fn [host ws message-body] "server")]
+      (is (= (process-message "localhost" "ws" {:endpoints ["cth://server"]}) "server")))))
+        

--- a/test/puppetlabs/cthun/validation_test.clj
+++ b/test/puppetlabs/cthun/validation_test.clj
@@ -6,13 +6,13 @@
   (testing "it raises an exception when an invalid message is received"
     (is (thrown? Exception (check-schema "invalid message"))))
   (testing "it returns the json structure when a valid message is passed"
-    (let [json {"version" "1"
-                "id" 1234
-                "endpoints" ["mco://host2.example.com/cnc/01"]
-                "data_schema" "/location/to/a/schema"
-                "sender" "mco://host1.example.com/controller/01",
-                "expires"  "2014-07-14T11:51:03+00:00"
-                "hops" [{"hop1" "2014-07-14T11:51:03+00:00"}]}]
+    (let [json {:version "1"
+                :id 1234
+                :endpoints ["mco://host2.example.com/cnc/01"]
+                :data_schema "/location/to/a/schema"
+                :sender "mco://host1.example.com/controller/01",
+                :expires  "2014-07-14T11:51:03+00:00"
+                :hops [{:hop1 "2014-07-14T11:51:03+00:00"}]}]
       (is (= json (check-schema json))))))
 
 (deftest validate-message-test

--- a/test/puppetlabs/cthun/websockets_test.clj
+++ b/test/puppetlabs/cthun/websockets_test.clj
@@ -1,0 +1,58 @@
+(ns puppetlabs.cthun.websockets-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.cthun.websockets :refer :all]))
+
+; Private websocket event handler tests
+
+(deftest on-connect!-test
+  (with-redefs [get-hostname (fn [ws] "localhost")
+                ring.adapter.jetty9/idle-timeout! (fn [ws timeout] true)]
+    (testing "It adds the fresh connection to the connection-map"
+      (let [connection-map (#'puppetlabs.cthun.websockets/on-connect! "ws")
+            host-map (connection-map "localhost")
+            socket-map (host-map "ws")]
+        (is (= (socket-map :socket-type) "undefined"))
+        (is (= (socket-map :status) "connected"))
+        (is (= (socket-map :user) "undefined"))
+        (is (= (socket-map :endpoint) "undefined"))))))
+
+(deftest on-text!-test
+  (with-redefs [puppetlabs.cthun.validation/validate-message (fn [message] true)
+                puppetlabs.cthun.connection-states/process-message (fn [hostname ws message] true)
+                get-hostname (fn [ws] "localhost")]
+  (testing "It processes a client message if the message body is valid"
+    (is (= (#'puppetlabs.cthun.websockets/on-text! "ws" "message") true))))
+  (with-redefs [puppetlabs.cthun.validation/validate-message (fn [message] false)]
+  (testing "It does not process a client message if the message body is invalid"
+    (is (= (#'puppetlabs.cthun.websockets/on-text! "ws" "message") nil)))))
+
+(deftest on-bytes!-test
+  (println "on-bytes!-test *** Pending ***"))
+
+(deftest on-error-test
+  (println "on-error-test *** Pending ***"))
+    
+(deftest on-close!-test
+  (with-redefs [get-hostname (fn [ws] "localhost")
+              ring.adapter.jetty9/idle-timeout! (fn [ws timeout] true)]
+    (testing "It removes the closed connection from the connection-map and endpoint-map"
+      (swap! puppetlabs.cthun.connection-states/connection-map {})
+      (#'puppetlabs.cthun.websockets/on-connect! "ws")
+      (#'puppetlabs.cthun.websockets/on-close! "ws" 1001 "Remove")
+      (is (= @puppetlabs.cthun.connection-states/connection-map {})))))
+
+; Public interface tests
+
+(deftest websocket-handlers-test
+  (testing "All the handler functions are defined"
+    (let [handlers (websocket-handlers)]
+      (is (= (type (handlers :on-connect)) puppetlabs.cthun.websockets$on_connect_BANG_))
+      (is (= (type (handlers :on-error)) puppetlabs.cthun.websockets$on_error))
+      (is (= (type (handlers :on-close)) puppetlabs.cthun.websockets$on_close_BANG_))
+      (is (= (type (handlers :on-text)) puppetlabs.cthun.websockets$on_text_BANG_))
+      (is (= (type (handlers :on-bytes)) puppetlabs.cthun.websockets$on_bytes_BANG_)))))
+
+(deftest start-jetty-test
+  (with-redefs [ring.adapter.jetty9/run-jetty (fn [app arg-map] true)]
+    (testing "It starts Jetty"
+      (is (= (start-jetty "app" "/cthun" "localhost" 8080) true)))))

--- a/test_message.txt
+++ b/test_message.txt
@@ -1,0 +1,10 @@
+{ "version" : "1",
+  "id" : 1045538569,
+  "endpoints" : ["cth://server"],
+  "data_schema" : "http://puppetlabs.com/loginschema",
+  "sender" : "mco://host1.example.com/controller/01",
+  "expires" : "2014-07-14T11:51:03+00:00",
+  "hops" : [{"foo" : "2014-07-14T11:51:03+00:00"}],
+  "data" : {"type" : "cthun_client",
+	          "user" : "psy"}
+}


### PR DESCRIPTION
This commit adds the concept of a login server message. Once a
connection has been established a client has to send a login message to
the server before it can send and receive messages.

For now we're keeping the login message very simple, only a username and
client type needs to be passed. This will be extended in the future.

This commit also ups to test coverage.
