### PR TITLE
CTH-81 populate hops field

### DIFF
--- a/src/puppetlabs/cthun/message.clj
+++ b/src/puppetlabs/cthun/message.clj
@@ -1,0 +1,12 @@
+(ns puppetlabs.cthun.message
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.kitchensink.core :as kitchensink]))
+
+(defn add-hop
+  "Returns the message with a hop for the specified 'stage' added."
+  ([message stage] (add-hop message stage (kitchensink/timestamp)))
+  ([message stage timestamp]
+     (let [hop {:server "cth://fake/server"
+                :time   timestamp
+                :stage  stage}]
+       (update-in message [:hops] conj hop))))

--- a/src/puppetlabs/cthun/validation.clj
+++ b/src/puppetlabs/cthun/validation.clj
@@ -12,6 +12,12 @@
   "Pattern that matches valid endpoints"
   (s/pred (partial re-matches #"cth://(server|.*/.*)") 'endpoint?))
 
+(def MessageHop
+  "Map that describes a step in message delivery"
+  {(s/required-key :server) Endpoint
+   (s/optional-key :stage) s/Str
+   (s/required-key :time) ISO8601})
+
 ; Message types
 (def ClientMessage
   "Defines the message format expected from a client"
@@ -21,7 +27,7 @@
    (s/required-key :data_schema) s/Str
    (s/required-key :sender) Endpoint
    (s/required-key :expires) ISO8601
-   (s/required-key :hops) [{s/Keyword ISO8601}] ;; TODO(richardc): should be in terms of Endpoint
+   (s/required-key :hops) [MessageHop]
    (s/optional-key :data) {s/Keyword s/Any}})
 
 ; Server message data types

--- a/test/puppetlabs/cthun/message_test.clj
+++ b/test/puppetlabs/cthun/message_test.clj
@@ -1,0 +1,29 @@
+(ns puppetlabs.cthun.message-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.cthun.message :refer :all]))
+
+
+(deftest add-hop-test
+  (with-redefs [puppetlabs.kitchensink.core/timestamp (fn [] "Tomorrow")]
+    (testing "it adds a hop"
+      (is (= {:hops [{:server "cth://fake/server"
+                      :time   "Another day"
+                      :stage  "potato"}]}
+             (add-hop {:hops []} "potato" "Another day"))))
+
+    (testing "it allows timestamp to be optional"
+      (is (= {:hops [{:server "cth://fake/server"
+                      :time   "Tomorrow"
+                      :stage  "potato"}]}
+             (add-hop {:hops []} "potato"))))
+
+    (testing "it adds hops in the expected order"
+      (is (= {:hops [{:server "cth://fake/server"
+                      :time   "Tomorrow"
+                      :stage  "potato"}
+                     {:server "cth://fake/server"
+                      :time   "Tomorrow"
+                      :stage  "mash"}]}
+             (-> {:hops []}
+                 (add-hop "potato")
+                 (add-hop "mash")))))))

--- a/test/puppetlabs/cthun/validation_test.clj
+++ b/test/puppetlabs/cthun/validation_test.clj
@@ -24,7 +24,8 @@
                 :data_schema "/location/to/a/schema"
                 :sender "cth://host1.example.com/controller/01",
                 :expires  "2014-07-14T11:51:03+00:00"
-                :hops [{:hop1 "2014-07-14T11:51:03+00:00"}]}]
+                :hops [{:server "cth://hop1/server"
+                        :time "2014-07-14T11:51:03+00:00"}]}]
       (is (= json (check-schema json))))))
 
 (deftest validate-message-test


### PR DESCRIPTION
The hops field of a cthun message exposes the steps a message took in moving
through the middleware.

Here we add a middleware/add-hop helper to populate this, and add it to the
obvious transit points.
