### PR TITLE
CTH-178 send error_message frames on incorrect messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,9 @@
                  ;; managed ThreadPool/ExecutorService
                  [io.aleph/dirigiste "0.1.0-alpha4"]
 
+                 ;; try+/throw+
+                 [slingshot "0.12.2"]
+
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]

--- a/test/puppetlabs/cthun/validation_test.clj
+++ b/test/puppetlabs/cthun/validation_test.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.cthun.validation-test
   (:require [clojure.test :refer :all]
             [puppetlabs.cthun.validation :refer :all]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
 (deftest endpoint-test
   (testing "it raises an exception for invalid endpoints"
@@ -22,10 +23,22 @@
     (is (= [ "localhost" "*" ] (explode-endpoint "cth://localhost/*")))
     (is (= [ "*" "agent" ] (explode-endpoint "cth://*/agent")))))
 
-(deftest check-certname-test
-  (testing "simple match"
-    (is (check-certname "cth://lolcathost/agent" "lolcathost")))
+(deftest validate-certname-test
+  (testing "simple match, no exception"
+    (try+
+     (validate-certname "cth://lolcathost/agent" "lolcathost")
+     (catch Object _
+       (is (not true) "No exception should be raised"))
+     (else (is true "No exception raised"))))
   (testing "simple mismatch"
-    (is (not (check-certname "cth://lolcathost/agent" "remotecat"))))
+    (try+
+     (validate-certname "cth://lolcathost/agent" "remotecat")
+     (catch map? m
+       (is (= :puppet.cthun.validation/identity-invalid) (:type m)))
+     (else (is (not true) "Expected an exception for remotecat"))))
   (testing "accidental regex collisions"
-    (is (not (check-certname "cth://lolcathost/agent" "lol.athost")))))
+    (try+
+     (validate-certname "cth://lolcathost/agent" "remotecat")
+     (catch map? m
+       (is (= :puppet.cthun.validation/identity-invalid) (:type m)))
+     (else (is (not true) "Expected an exception for lol.athost")))))


### PR DESCRIPTION
Here we introduce a new error_message schema, and send a message of this schema on receiving a malformed or invalid message.

As part of this we switch to using slingshot and throw+ typed exceptions, to allow the multiple ways a message may be considered invalid to be communicated.
