### PR TITLE
CTH-242 remove non-ssl http servers

### DIFF
--- a/src/puppetlabs/cthun_core.clj
+++ b/src/puppetlabs/cthun_core.clj
@@ -6,11 +6,7 @@
             [puppetlabs.cthun.metrics :as metrics]
             [puppetlabs.puppetdb.mq :as mq]))
 
-(defn- websocket-app
-  [conf]
-  (log/info "Websocket App starting"))
-
-(defn- metrics-app
+(defn- app
   [conf]
   (log/info "Metrics App initiated")
   {:status 200
@@ -42,8 +38,7 @@
   [broker]
   (let [{:keys [host port url-prefix config activemq-broker]} broker]
     (mq/start-broker! activemq-broker)
-    (websockets/start-metrics metrics-app)
-    (websockets/start-jetty websocket-app url-prefix host port config)))
+    (websockets/start-jetty app url-prefix host port config)))
 
 (defn stop
   [broker]

--- a/test-resources/config.ini
+++ b/test-resources/config.ini
@@ -8,7 +8,7 @@ enabled = true
 
 [cthun]
 host = localhost
-port = 8080
+port = 8090
 url-prefix = /cthun
 
 ;; Spool used by the queuing service
@@ -23,8 +23,6 @@ broker-spool = ./test-resources/tmp/activemq
 ;; Maximum number of threads in the delivery pool.  Default is 64
 ; max-delivery-threads = 64
 
-;; For now you can disable ssl by commenting out ssl-port
-ssl-port    = 8090
 ssl-key     = ./test-resources/ssl/private_keys/cthun-server.pem
 ssl-cert    = ./test-resources/ssl/certs/cthun-server.pem
 ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem

--- a/test/puppetlabs/cthun/websockets_test.clj
+++ b/test/puppetlabs/cthun/websockets_test.clj
@@ -60,6 +60,7 @@
       (is (fn? (handlers :on-bytes))))))
 
 (deftest start-jetty-test
-  (with-redefs [ring.adapter.jetty9/run-jetty (fn [app arg-map] true)]
+  (with-redefs [puppetlabs.trapperkeeper.services.webserver.jetty9-config/pem-ssl-config->keystore-ssl-config (fn [config] {})
+                ring.adapter.jetty9/run-jetty (fn [app arg-map] true)]
     (testing "It starts Jetty"
       (is (= (start-jetty "app" "/cthun" "localhost" 8080 {}) true)))))


### PR DESCRIPTION
Here we remove the :8080 non-ssl websockets context and the :3000
metrics port, folding the metrics app into the app for the main
webserver context.

We downgrade the client-auth requirement from need to want, so a
user can browse the mmetrics app, but we still need certs to use
the broker.
