### PR TITLE
(MAINT) Add user repl namespace

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,38 @@
+(ns user
+  (:require [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
+            [puppetlabs.trapperkeeper.config :as tk-config]
+            [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [clojure.tools.namespace.repl :as repl]))
+
+;; NOTE: in some other projects, where we need to support per-developer config
+;;  variations, we'll put this code into a namespace called 'user-repl', and
+;;  allow devs to build out their own 'user.clj' that wraps it.  See Puppet Server
+;;  for an example, but YMMV and this simpler approach may be fine.
+
+(def system nil)
+
+(defn init []
+  (alter-var-root #'system
+    (fn [_] (let [services (tk-bootstrap/parse-bootstrap-config! "./test-resources/bootstrap.cfg")
+                  config (tk-config/load-config "./test-resources/config.ini")]
+              (tk/build-app services config))))
+  (alter-var-root #'system tk-app/init)
+  (tk-app/check-for-errors! system))
+
+(defn start []
+  (alter-var-root #'system
+    (fn [s] (if s (tk-app/start s))))
+  (tk-app/check-for-errors! system))
+
+(defn stop []
+  (alter-var-root #'system
+    (fn [s] (when s (tk-app/stop s)))))
+
+(defn go []
+  (init)
+  (start))
+
+(defn reset []
+  (stop)
+  (repl/refresh :after 'user/go))

--- a/project.clj
+++ b/project.clj
@@ -46,9 +46,6 @@
 
                  [puppetlabs/cthun-message "0.1.0"]
 
-                 [puppetlabs/ssl-utils "0.8.0"]
-                 [me.raynes/fs "1.4.5"]
-
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.activemq/activemq-core "5.6.0" :exclusions [org.slf4j/slf4j-api org.fusesource.fuse-extra/fusemq-leveldb]]
@@ -60,8 +57,14 @@
 
   :test-paths ["test" "test-resources"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]}}
+  :profiles {:dev {:source-paths ["dev"]
+                   :dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+                                  [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
+                                  [puppetlabs/ssl-utils "0.8.0"]
+                                  [me.raynes/fs "1.4.5"]
+                                  [org.clojure/tools.namespace "0.2.4"]]}}
+
+  :repl-options {:init-ns user}
 
   ;; Enable occasionally to check we have no interop hotspots that need better type hinting
   ; :global-vars {*warn-on-reflection* true}

--- a/src/puppetlabs/cthun/websockets.clj
+++ b/src/puppetlabs/cthun/websockets.clj
@@ -168,13 +168,14 @@
       (.setConnectors server connectors))
     server))
 
-(defn start-jetty
+(s/defn ^:always-validate start-jetty :- Server
   [app prefix host port config]
   (let [jetty-config {:websockets {prefix (websocket-handlers)}
                       :ssl-port port
                       :host host
                       :client-auth :want
-                      :ssl-crl-path (:ssl-crl-path config)}
+                      :ssl-crl-path (:ssl-crl-path config)
+                      :join? false}
         jetty-config (merge jetty-config (jetty9-config/pem-ssl-config->keystore-ssl-config
                                           (select-keys config [:ssl-key :ssl-cert :ssl-ca-cert])))
         jetty-config (assoc jetty-config :configurator (make-jetty9-configurator jetty-config))]

--- a/src/puppetlabs/cthun_service.clj
+++ b/src/puppetlabs/cthun_service.clj
@@ -20,12 +20,13 @@
           (assoc context :cthun service)))
   (start [this context]
          (log/info "Starting cthun service")
-         (let [service (:cthun (service-context this))]
-           (core/start service))
-         context)
+    (let [service (:cthun (service-context this))
+          ;; TODO: these Jetty lines will go away if we switch to tk-j9
+          jetty-server (core/start service)]
+         (assoc context :jetty-server jetty-server)))
   (stop [this context]
         (log/info "Shutting down cthun service")
-        (let [service (:cthun (service-context this))]
+        (let [service (select-keys (service-context this) [:cthun :jetty-server])]
           (core/stop service))
         context)
   (state [this caller]

--- a/test/puppetlabs/cthun/websockets_test.clj
+++ b/test/puppetlabs/cthun/websockets_test.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.cthun.websockets-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.cthun.websockets :refer :all]))
+            [puppetlabs.cthun.websockets :refer :all])
+  (:import (org.eclipse.jetty.server Server)))
 
 (deftest websocket-handlers-test
   (testing "All the handler functions are defined"
@@ -13,6 +14,8 @@
 
 (deftest start-jetty-test
   (with-redefs [puppetlabs.trapperkeeper.services.webserver.jetty9-config/pem-ssl-config->keystore-ssl-config (fn [config] {})
-                ring.adapter.jetty9/run-jetty (fn [app arg-map] true)]
+                ring.adapter.jetty9/run-jetty (fn [app arg-map] (Server.))]
     (testing "It starts Jetty"
-      (is (= (start-jetty "app" "/cthun" "localhost" 8080 {}) true)))))
+      (start-jetty "app" "/cthun" "localhost" 8080 {})
+      ;; just confirming that we got here and no exceptions were thrown
+      (is (true? true)))))


### PR DESCRIPTION
This commit does the following:
- Small tweaks to lifecycle management of Jetty server, such that
  it does not block on startup (and thus the TK `start` lifecycle
  function returns control), and adds `stop` functionality to
  shut Jetty down cleanly.
- Adds 'user.clj' namespace, sets it as the default for the REPL.
  This allows you to start the app directly from the REPL (via `(go)`).
  You can also call `(stop)` to stop the app, or `(reset)` to reload
  the Clojure code and restart the app without restarting the JVM.

I haven't tested the REPL lifecycle stuff with a real live client;
have only validated that I can successfully reload the app multiple
times in the same REPL session without errors.  It's possible
that some of the global state might not quite work properly with
this pattern.
