### PR TITLE
CTH-243 add lein-release and lein-ezbake configurations

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -1,0 +1,2 @@
+puppetlabs.cthun-service/cthun-service
+puppetlabs.cthun.inventory.in-memory/inventory-service

--- a/ezbake/config/conf.d/cthun.conf
+++ b/ezbake/config/conf.d/cthun.conf
@@ -1,0 +1,31 @@
+cthun: {
+    host = 0.0.0.0
+
+    url-prefix = /cthun
+
+    # Spool used by the queuing service
+    broker-spool = /opt/puppetlabs/server/data/cthun
+
+    ## Number of consumers for the accept queue.  Default is 4
+    # accept-consumers = 4
+
+    ## Number of consumers for the redeliver queue.  Default is 2
+    # redeliver-consumers = 2
+
+    ## Maximum number of threads in the delivery pool.  Default is 64
+    # max-delivery-threads = 64
+
+    ssl-port    = 8090
+
+    # Private key path
+    # ssl-key = <private_key_path>
+
+    # Public certificate path
+    # ssl-cert = <public_cert_path>
+
+    # Certificate authority path
+    # ssl-ca-cert = <ca_cert_path>
+
+    # Certificate revocation list path
+    # ssl-crl-path = <crl_path>
+}

--- a/ezbake/config/conf.d/global.conf
+++ b/ezbake/config/conf.d/global.conf
@@ -1,0 +1,5 @@
+global: {
+    # Path to logback logging configuration file; for more
+    # info, see http://logback.qos.ch/manual/configuration.html
+    logging-config: /etc/puppetlabs/cthun/logback.xml
+}

--- a/ezbake/config/logback.xml
+++ b/ezbake/config/logback.xml
@@ -1,0 +1,23 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <!-- TODO: this path should not be hard-coded -->
+        <file>/var/log/puppetlabs/cthun/cthun.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="info">
+        <appender-ref ref="${logappender}"/>
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (def tk-version "1.1.1")
 (def ks-version "1.1.0")
+(def cthun-version "0.1.0-SNAPSHOT")
 
 (defn deploy-info
   [url]
@@ -8,7 +9,7 @@
     :password :env/nexus_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/cthun "0.1.0-SNAPSHOT"
+(defproject puppetlabs/cthun cthun-version
   :description "cthun fabric messaging server"
   :url "https://github.com/puppetlabs/cthun"
   :license {:name ""
@@ -69,6 +70,12 @@
 
   :lein-release {:scm :git, :deploy-via :lein-deploy}
 
+  :uberjar-name "cthun-release.jar"
+
+  :lein-ezbake {:resources {:type jar
+                            :dir "tmp/config"}
+                :config-dir "ezbake/config"}
+
   :test-paths ["test" "test-resources"]
 
   :profiles {:dev {:source-paths ["dev"]
@@ -76,7 +83,10 @@
                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
                                   [puppetlabs/ssl-utils "0.8.0"]
                                   [me.raynes/fs "1.4.5"]
-                                  [org.clojure/tools.namespace "0.2.4"]]}}
+                                  [org.clojure/tools.namespace "0.2.4"]]}
+             :ezbake {:dependencies ^:replace [[puppetlabs/cthun ~cthun-version]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.11"]]
+                      :name "cthun"}}
 
   :repl-options {:init-ns user}
 


### PR DESCRIPTION
Here we add the configuration settings and files needed to allow us to publish rpms to an internal packaging repo.
