### PR TITLE
CTH-249 Allow the later session to connect

### DIFF
--- a/test/puppetlabs/cthun/connection_states_test.clj
+++ b/test/puppetlabs/cthun/connection_states_test.clj
@@ -81,13 +81,16 @@
           (is (= (:created-at connection) "squirrel"))
           (is (= "cth://localhost/controller" (:uri connection)))))
 
-      (testing "It does not allow a login to happen from two locations for the same uri"
+      (testing "It allows a login to from two locations for the same uri, but disconnects the first"
         (reset! uri-map {})
         (reset! connection-map {})
         (add-connection "localhost" "ws1")
+        (is (= ["ws1"] (keys @connection-map)))
         (add-connection "localhost" "ws2")
+        (is (= ["ws1" "ws2"] (sort (keys @connection-map))))
         (process-session-association-message "localhost" "ws1" login-message)
-        (is (not (process-session-association-message "localhost" "ws2" login-message))))
+        (is (process-session-association-message "localhost" "ws2" login-message))
+        (is (= ["ws2"] (keys @connection-map))))
 
       (testing "It does not allow a login to happen twice on the same websocket"
         (reset! uri-map {})


### PR DESCRIPTION
Previously when a connection attempted to associate with a client
URI that was already active within the network a second attempt to
associate with that URI was denied, as there could only be one.
This behaviour however isn't useful in the case where a client loses
its connection in an unclean manner and needs to re-associate before
the server notices that the previous client connection has terminated.

Here we change the logic to allow the later session association of
the same client URI to disconnect the old connection and usurp the
identity.
