### PR TITLE
(RE-5212) Switch project build-type to PE

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -74,7 +74,8 @@
 
   :lein-ezbake {:resources {:type jar
                             :dir "tmp/config"}
-                :config-dir "ezbake/config"}
+                :config-dir "ezbake/config"
+                :build-type "pe" }
 
   :test-paths ["test" "test-resources"]
 


### PR DESCRIPTION
Previously we were using the implied FOSS type of ezbake. Thus we were
buildling for many platforms, but not the ones we need for PE
integration.

This commit flips the build-type to PE, which should allow packages to
come out for all platforms needed for our next feature release of Puppet
Enterprise.
