### PR TITLE
(RE-5213) Remove project name from project summary

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
     :sign-releases false })
 
 (defproject puppetlabs/cthun cthun-version
-  :description "cthun fabric messaging server"
+  :description "puppet fabric messaging server"
   :url "https://github.com/puppetlabs/cthun"
   :license {:name ""
             :url ""}


### PR DESCRIPTION
Having the name in teh description of th project is like using a word to
define a word. It's also considered bad practice and throws lint
warnings for packaging.

It's a simple fix, so here's a patch. I've changed cthun to puppet.
