### PR TITLE
CTH-275 Change webserver wrapper to be tk-webserver-j9

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -1,2 +1,3 @@
 puppetlabs.cthun-service/cthun-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service

--- a/ezbake/config/conf.d/cthun.conf
+++ b/ezbake/config/conf.d/cthun.conf
@@ -1,6 +1,4 @@
 cthun: {
-    host = 0.0.0.0
-
     url-prefix = /cthun
 
     # Spool used by the queuing service
@@ -11,18 +9,4 @@ cthun: {
 
     ## Number of consumers for the delivery queue.  Default is 16
     # delivery-consumers = 16
-
-    ssl-port    = 8090
-
-    # Private key path
-    # ssl-key = <private_key_path>
-
-    # Public certificate path
-    # ssl-cert = <public_cert_path>
-
-    # Certificate authority path
-    # ssl-ca-cert = <ca_cert_path>
-
-    # Certificate revocation list path
-    # ssl-crl-path = <crl_path>
 }

--- a/ezbake/config/conf.d/webserver.conf
+++ b/ezbake/config/conf.d/webserver.conf
@@ -1,0 +1,17 @@
+webserver: {
+    client-auth = want
+    ssl-host = 0.0.0.0
+    ssl-port = 8090
+
+    # Private key path
+    # ssl-key = <private_key_path>
+
+    # Public certificate path
+    # ssl-cert = <public_cert_path>
+
+    # Certificate authority path
+    # ssl-ca-cert = <ca_cert_path>
+
+    # Certificate revocation list path
+    # ssl-crl-path = <crl_path>
+}

--- a/project.clj
+++ b/project.clj
@@ -26,16 +26,7 @@
                  [org.clojure/core.async "0.1.338.0-5c5012-alpha"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.1"]
-
-                 [info.sunng/ring-jetty9-adapter "0.8.5"
-                  :exclusions [org.eclipse.jetty/jetty-util
-                               org.eclipse.jetty/jetty-io
-                               org.eclipse.jetty/jetty-http
-                               org.eclipse.jetty/jetty-security
-                               org.eclipse.jetty/jetty-server
-                               org.eclipse.jetty/jetty-servlet
-                               ring/ring-servlet]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.4.0"]
 
                  [cheshire "5.5.0"]
                  [prismatic/schema "0.4.3"]

--- a/src/puppetlabs/cthun/websockets.clj
+++ b/src/puppetlabs/cthun/websockets.clj
@@ -1,57 +1,44 @@
 (ns puppetlabs.cthun.websockets
-  (:import (org.eclipse.jetty.server
-            Server ServerConnector ConnectionFactory HttpConnectionFactory
-            Connector HttpConfiguration Request)
-           (org.eclipse.jetty.websocket.api
-            WebSocketAdapter))
-  (:require  [clojure.tools.logging :as log]
-             [ring.adapter.jetty9 :as jetty-adapter]
-             [puppetlabs.cthun.validation :as validation]
-             [puppetlabs.cthun.message :as message]
-             [puppetlabs.cthun.connection-states :as cs]
-             [puppetlabs.kitchensink.core :as kitchensink]
-             [metrics.counters :refer [inc! dec!]]
-             [metrics.meters :refer [mark!]]
-             [metrics.timers :refer [time!]]
-             [puppetlabs.cthun.metrics :as metrics]
-             [puppetlabs.trapperkeeper.services.webserver.jetty9-config :as jetty9-config]
-             [schema.core :as s]
-             [slingshot.slingshot :refer [try+]]))
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.cthun.validation :as validation]
+            [puppetlabs.cthun.message :as message]
+            [puppetlabs.cthun.connection-states :as cs]
+            [puppetlabs.kitchensink.core :as kitchensink]
+            [metrics.counters :refer [inc! dec!]]
+            [metrics.meters :refer [mark!]]
+            [metrics.timers :refer [time!]]
+            [puppetlabs.cthun.metrics :as metrics]
+            [puppetlabs.experimental.websockets.client :as websocket-client]
+            [schema.core :as s]
+            [slingshot.slingshot :refer [try+]]))
 
-(def remote-cns (atom {}))
-
-(defn- get-hostname*
-  "Get the hostname or client certificate name from a websocket"
-  [^WebSocketAdapter ws]
-  (if (.. ws getSession getUpgradeRequest isSecure)
-    (let [remoteaddr (.. ws getSession getRemoteAddress toString)
-          cn         (get @remote-cns remoteaddr)]
-      cn)
-    (.getHostString (jetty-adapter/remote-addr ws))))
-
-(def get-hostname (memoize get-hostname*))
+(defn get-cn
+  "Get the hostname client certificate name from a websocket"
+  [ws]
+  (when-let [cert (first (websocket-client/peer-certs ws))]
+    (kitchensink/cn-for-cert cert)))
 
 ; Websocket event handlers
 
 (defn- on-connect!
   "OnConnect websocket event handler"
-  [^WebSocketAdapter ws]
+  [ws]
   (time! metrics/time-in-on-connect
-         ((let [host (get-hostname ws)
+         ((let [host (get-cn ws)
                 idle-timeout (* 1000 60 15)]
-            (log/debug "Connection established from host:" host)
-            (jetty-adapter/idle-timeout! ws idle-timeout)
+            (log/info "Connection established from host:" host " on " ws)
+            (websocket-client/idle-timeout! ws idle-timeout)
             (cs/add-connection host ws))
           (inc! metrics/active-connections))))
 
 (defn on-message!
-  [^WebSocketAdapter ws bytes]
+  [ws bytes]
   (let [timestamp (kitchensink/timestamp)]
     (inc! metrics/total-messages-in)
     (mark! metrics/rate-messages-in)
     (time! metrics/time-in-on-text
-           (let [host (get-hostname ws)]
-             (log/info "Received message from client" host)
+           (let [host (get-cn ws)]
+             (log/info "Received message from client" host " on " ws)
              (try+
               (let [message (message/decode bytes)]
                 (validation/validate-certname (:sender message) host)
@@ -67,31 +54,31 @@
                                         (message/set-json-data error-body))]
                   (s/validate validation/ErrorMessage error-body)
                   (log/warn "sending error message" error-body)
-                  (jetty-adapter/send! ws (message/encode error-message))))
+                  (websocket-client/send! ws (message/encode error-message))))
               (catch Throwable e
                 (log/error "Unhandled exception" e)))))))
 
 (defn- on-text!
   "OnMessage (text) websocket event handler"
-  [^WebSocketAdapter ws message]
+  [ws message]
   (on-message! ws (message/string->bytes message)))
 
 (defn- on-bytes!
   "OnMessage (binary) websocket event handler"
-  [^WebSocketAdapter ws bytes offset len]
+  [ws bytes offset len]
   (on-message! ws bytes))
 
 (defn- on-error
   "OnError websocket event handler"
-  [^WebSocketAdapter ws e]
+  [ws e]
   (log/error e)
   (dec! metrics/active-connections))
 
 (defn- on-close!
   "OnClose websocket event handler"
-  [^WebSocketAdapter ws status-code reason]
-  (let [hostname (get-hostname ws)]
-    (log/info "Connection from" hostname "terminated with statuscode:" status-code " Reason:" reason)
+  [ws status-code reason]
+  (let [hostname (get-cn ws)]
+    (log/info "Connection from" hostname " on " ws " terminated with statuscode:" status-code " Reason:" reason)
     (dec! metrics/active-connections)
     (time! metrics/time-in-on-close
            (cs/remove-connection hostname ws))))
@@ -106,76 +93,3 @@
    :on-close on-close!
    :on-text on-text!
    :on-bytes on-bytes!})
-
-(defn- make-cthun-customizer
-  "Returns a customizer that updates the remote-cns map of Remote
-  Address to certificate common name.  Needs to be after a
-  org.eclipse.jetty.server.SecureRequestCustomizer which populates the
-  javax.servlet.request.X509Certificate attribute"
-  []
-  (reify org.eclipse.jetty.server.HttpConfiguration$Customizer
-    (^void customize [this ^Connector connector ^HttpConfiguration config ^Request request]
-      (if-let [ssl-client-cert (first (.getAttribute request "javax.servlet.request.X509Certificate"))]
-        (let [remoteaddr (.. request getRemoteInetSocketAddress toString)]
-          (swap! remote-cns assoc remoteaddr (kitchensink/cn-for-cert ssl-client-cert)))))))
-
-(defn- make-ssl-customizers
-  "Returns the customizers we want to apply to the ssl Configurator"
-  []
-  [(org.eclipse.jetty.server.SecureRequestCustomizer.)
-   (make-cthun-customizer)])
-
-;; TODO(richardc) A lot of this code is here because
-;; ring.adapter.jetty9 doesn't give us a way of specifying https only,
-;; or the ability to call .setCustomizers on the HttpConfiguration
-;; object.  We rudely reach into it and call private functions to get
-;; the HttpConfiguration to set the customizers on.
-;; We should propose a saner way of extending this.
-(defn- https-config
-  "Returns a jetty.server.HttpConfiguration with the
-  desired Customizers set"
-  [options]
-  (doto (#'jetty-adapter/http-config options)
-    (.setCustomizers (make-ssl-customizers))))
-
-(defn- make-ssl-context-factory
-  "Returns a jetty.util.SslContextFactory.  This is the one from
-  ring.adapter.jetty9 with options set to use the crl from
-  ssl-crl-path, and to verify the peer"
-  [options]
-  (let [factory (#'jetty-adapter/ssl-context-factory options)]
-    (.setCrlPath factory (:ssl-crl-path options))
-    (.setValidatePeerCerts factory true)
-    factory))
-
-(defn- make-jetty9-configurator
-  "Returns a configurator function that is called with
-  jetty.server.Server before it's started.  We take this as a way of
-  completely replacing the connectors with an ssl connector with the
-  customizers we need.  This is heavy and involves more private
-  function spelunking."
-  [options]
-  (fn [server]
-    (let [https-configuration (https-config options)
-          https-connector (doto (ServerConnector.
-                                 ^Server server
-                                 (make-ssl-context-factory options)
-                                 (into-array ConnectionFactory [(HttpConnectionFactory. https-configuration)]))
-                            (.setPort (:ssl-port options))
-                            (.setHost (:host options)))
-          connectors (into-array [https-connector])]
-      (.setConnectors server connectors))
-    server))
-
-(s/defn ^:always-validate start-jetty :- Server
-  [app prefix host port config]
-  (let [jetty-config {:websockets {prefix (websocket-handlers)}
-                      :ssl-port port
-                      :host host
-                      :client-auth :want
-                      :ssl-crl-path (:ssl-crl-path config)
-                      :join? false}
-        jetty-config (merge jetty-config (jetty9-config/pem-ssl-config->keystore-ssl-config
-                                          (select-keys config [:ssl-key :ssl-cert :ssl-ca-cert])))
-        jetty-config (assoc jetty-config :configurator (make-jetty9-configurator jetty-config))]
-    (jetty-adapter/run-jetty app jetty-config)))

--- a/src/puppetlabs/cthun_core.clj
+++ b/src/puppetlabs/cthun_core.clj
@@ -4,10 +4,9 @@
             [puppetlabs.cthun.connection-states :as cs]
             [puppetlabs.cthun.metrics :as metrics]
             [puppetlabs.puppetdb.mq :as mq]
-            [schema.core :as s])
-  (:import (org.eclipse.jetty.server Server)))
+            [schema.core :as s]))
 
-(defn- app
+(defn app
   [conf]
   (log/info "Metrics App initiated")
   {:status 200
@@ -16,38 +15,24 @@
 
 (defn make-cthun-broker
   [get-in-config inventory]
-  (let [config (get-in-config [:cthun])
-        host (get-in-config [:cthun :host])
-        port (get-in-config [:cthun :port])
-        url-prefix (get-in-config [:cthun :url-prefix])
+  (let [url-prefix (get-in-config [:cthun :url-prefix])
         activemq-spool (get-in-config [:cthun :broker-spool] "tmp/activemq")
         activemq-broker (mq/build-embedded-broker activemq-spool)
         accept-consumers   (get-in-config [:cthun :accept-consumers] 4)
         delivery-consumers (get-in-config [:cthun :delivery-consumers] 16)]
     (cs/use-this-inventory inventory)
     (cs/subscribe-to-queues accept-consumers delivery-consumers)
-    {:host host
-     :port port
-     :url-prefix url-prefix
-     :config config
-     :activemq-broker activemq-broker}))
-
-(s/defn ^:always-validate stop-jetty
-  [jetty-server :- Server]
-  (.stop jetty-server)
-  (.join jetty-server))
+    {:activemq-broker activemq-broker}))
 
 (defn start
   [broker]
-  (let [{:keys [host port url-prefix config activemq-broker]} broker]
-    (mq/start-broker! activemq-broker)
-    (websockets/start-jetty app url-prefix host port config)))
+  (let [{:keys [activemq-broker]} broker]
+    (mq/start-broker! activemq-broker)))
 
 (defn stop
-  [{:keys [cthun jetty-server] :as service}]
+  [{:keys [cthun] :as service}]
   (let [{:keys [activemq-broker]} cthun]
-    (mq/stop-broker! activemq-broker)
-    (stop-jetty jetty-server)))
+    (mq/stop-broker! activemq-broker)))
 
 (defn state
   "Return the service state"

--- a/src/puppetlabs/cthun_service.clj
+++ b/src/puppetlabs/cthun_service.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.cthun-service
   (:require [clojure.tools.logging :as log]
             [puppetlabs.cthun-core :as core]
+            [puppetlabs.cthun.websockets :as websockets]
             [puppetlabs.trapperkeeper.app :as app]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
@@ -13,21 +14,24 @@
 (trapperkeeper/defservice cthun-service
   CthunService
   [[:ConfigService get-in-config]
+   [:WebserverService add-ring-handler add-websocket-handler]
    InventoryService]
   (init [this context]
         (log/info "Initializing cthun service")
-        (let [service (core/make-cthun-broker get-in-config InventoryService)]
+        (let [cthun-path (get-in-config [:cthun :url-prefix] "/cthun")
+              service (core/make-cthun-broker get-in-config InventoryService)]
+          (add-ring-handler core/app "/")
+          (add-websocket-handler (websockets/websocket-handlers) cthun-path)
           (assoc context :cthun service)))
   (start [this context]
          (log/info "Starting cthun service")
-    (let [service (:cthun (service-context this))
-          ;; TODO: these Jetty lines will go away if we switch to tk-j9
-          jetty-server (core/start service)]
-         (assoc context :jetty-server jetty-server)))
+         (let [cthun (:cthun (service-context this))]
+           (core/start cthun))
+         context)
   (stop [this context]
         (log/info "Shutting down cthun service")
-        (let [service (select-keys (service-context this) [:cthun :jetty-server])]
-          (core/stop service))
+        (let [cthun (:cthun (service-context this))]
+          (core/stop cthun))
         context)
   (state [this caller]
          (core/state caller)))

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -1,3 +1,4 @@
 puppetlabs.cthun-service/cthun-service
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service

--- a/test-resources/conf.d/cthun.conf
+++ b/test-resources/conf.d/cthun.conf
@@ -1,6 +1,4 @@
 cthun: {
-    host = localhost
-    port = 8090
     url-prefix = /cthun
 
     ## Spool used by the queuing service
@@ -11,9 +9,4 @@ cthun: {
 
     ## Number of consumers for the delivery queue.  Default is 16
     # delivery-consumers = 16
-
-    ssl-key     = ./test-resources/ssl/private_keys/cthun-server.pem
-    ssl-cert    = ./test-resources/ssl/certs/cthun-server.pem
-    ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem
-    ssl-crl-path = ./test-resources/ssl/ca/ca_crl.pem
 }

--- a/test-resources/conf.d/webserver.conf
+++ b/test-resources/conf.d/webserver.conf
@@ -1,0 +1,9 @@
+webserver: {
+    client-auth = want
+    ssl-host    = 0.0.0.0
+    ssl-port    = 8090
+    ssl-key     = ./test-resources/ssl/private_keys/cthun-server.pem
+    ssl-cert    = ./test-resources/ssl/certs/cthun-server.pem
+    ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem
+    ssl-crl-path = ./test-resources/ssl/ca/ca_crl.pem
+}

--- a/test/puppetlabs/cthun/connection_states_test.clj
+++ b/test/puppetlabs/cthun/connection_states_test.clj
@@ -64,8 +64,8 @@
     (is (= {} @connection-map))))
 
 (deftest process-session-association-message-test
-  (with-redefs [ring.adapter.jetty9/close! (fn [ws] false)
-                ring.adapter.jetty9/send! (fn [ws bytes] false)]
+  (with-redefs [puppetlabs.experimental.websockets.client/close! (fn [ws] false)
+                puppetlabs.experimental.websockets.client/send! (fn [ws bytes] false)]
     (let [login-message {:id ""
                          :sender "cth://localhost/controller"
                          :message_type "http://puppetlabs.com/login_message"}]

--- a/test/puppetlabs/cthun/websockets_test.clj
+++ b/test/puppetlabs/cthun/websockets_test.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.cthun.websockets-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.cthun.websockets :refer :all])
-  (:import (org.eclipse.jetty.server Server)))
+            [puppetlabs.cthun.websockets :refer :all]))
 
 (deftest websocket-handlers-test
   (testing "All the handler functions are defined"
@@ -11,11 +10,3 @@
       (is (fn? (handlers :on-close)))
       (is (fn? (handlers :on-text)))
       (is (fn? (handlers :on-bytes))))))
-
-(deftest start-jetty-test
-  (with-redefs [puppetlabs.trapperkeeper.services.webserver.jetty9-config/pem-ssl-config->keystore-ssl-config (fn [config] {})
-                ring.adapter.jetty9/run-jetty (fn [app arg-map] (Server.))]
-    (testing "It starts Jetty"
-      (start-jetty "app" "/cthun" "localhost" 8080 {})
-      ;; just confirming that we got here and no exceptions were thrown
-      (is (true? true)))))


### PR DESCRIPTION
Here we remove the use of sunng/ring-jetty9-adapter instead using
add-websockets-handler from trapperkeeper-webserver-jetty9.

Some reorganisation of configuration is required here, as we get to move
settings from the [cthun] namespace into the [webserver] one.
