### PR TITLE
CTH-280 Add a basic authorization subsystem

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -1,3 +1,4 @@
 puppetlabs.cthun.broker-service/broker-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
+puppetlabs.cthun.authorization.basic-service/authorization-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service

--- a/src/puppetlabs/cthun/authorization.clj
+++ b/src/puppetlabs/cthun/authorization.clj
@@ -1,0 +1,4 @@
+(ns puppetlabs.cthun.authorization)
+
+(defprotocol AuthorizationService
+  (authorized [this message]))

--- a/src/puppetlabs/cthun/authorization/basic_core.clj
+++ b/src/puppetlabs/cthun/authorization/basic_core.clj
@@ -1,0 +1,58 @@
+(ns puppetlabs.cthun.authorization.basic-core
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.cthun.message :as message]
+            ;; TODO(richardc): explode-uri should probably move to
+            ;; puppetlabs.cthun.protocol.helpers
+            [puppetlabs.cthun.broker-core :refer [explode-uri]]
+            [schema.core :as s]))
+
+(def Decision
+  (s/enum :allow :deny))
+
+(def Jump
+  {:target s/Keyword})
+
+(def Action
+  (s/if map? Jump Decision))
+
+(def Rule
+  {(s/optional-key :sender) s/Str
+   (s/optional-key :message_type) s/Str
+   :action Action})
+
+(def Table
+  {:default Decision
+   (s/optional-key :rules) [Rule]})
+
+(def Rules
+  {s/Keyword Table})
+
+;; TODO(richardc) - un-fugly this
+(s/defn ^:always-validate rule-matches? :- s/Bool
+  [rule :- Rule message :- message/Message]
+  (let [rule-message_type    (:message_type rule)
+        rule-sender          (:sender rule)
+        message-message_type (:message_type message)
+        [message-sender]     (explode-uri (:sender message))]
+    (and (or (= rule-sender nil) (= rule-sender message-sender))
+         (or (= rule-message_type nil) (= rule-message_type message-message_type)))))
+
+(s/defn ^:always-validate authorized :- s/Bool
+  [rules :- Rules message :- message/Message]
+  (loop [table   :accept
+         been    #{}
+         default (get-in rules [table :default] :deny)]
+    (let [rule (first (filter (fn [r] (rule-matches? r message)) (get-in rules [table :rules])))]
+      (if (not rule)
+        (= default :allow) ;; no rule matched, use table default
+        (let [action (:action rule)]
+          (if (not (map? action))
+            (= action :allow) ;; rule matched, not a jump, do that
+            (let [target  (:target action)
+                  been    (conj been table)
+                  default (get-in rules [target :default] :deny)]
+              (if (contains? been target)
+                (do
+                  (log/error "Loop detected in rules " been " -> " target ". Denying message")
+                  false)
+                (recur target been default)))))))))

--- a/src/puppetlabs/cthun/authorization/basic_service.clj
+++ b/src/puppetlabs/cthun/authorization/basic_service.clj
@@ -1,0 +1,12 @@
+(ns puppetlabs.cthun.authorization.basic-service
+ (:require [puppetlabs.cthun.authorization :refer [AuthorizationService]]
+           [puppetlabs.cthun.authorization.basic-core :as core]
+           [puppetlabs.trapperkeeper.core :refer [defservice]]
+           [puppetlabs.trapperkeeper.services :refer [service-context]]))
+
+(defservice authorization-service
+  AuthorizationService
+  [[:ConfigService get-in-config]]
+  (authorized [this message]
+              (let [rules (get-in-config [:cthun-basic-authz] {:accept {:default :allow}})]
+                (core/authorized rules message))))

--- a/src/puppetlabs/cthun/broker_service.clj
+++ b/src/puppetlabs/cthun/broker_service.clj
@@ -7,7 +7,8 @@
 (trapperkeeper/defservice broker-service
   [[:ConfigService get-in-config]
    [:WebserverService add-ring-handler add-websocket-handler]
-   [:InventoryService record-client find-clients]]
+   [:InventoryService record-client find-clients]
+   [:AuthorizationService authorized]]
   (init [this context]
         (log/info "Initializing broker service")
         (let [path               (get-in-config [:cthun :url-prefix] "/cthun")
@@ -21,7 +22,8 @@
                                              :add-ring-handler add-ring-handler
                                              :add-websocket-handler add-websocket-handler
                                              :record-client record-client
-                                             :find-clients find-clients})]
+                                             :find-clients find-clients
+                                             :authorized authorized})]
           (assoc context :broker broker)))
   (start [this context]
          (log/info "Starting broker service")

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -2,3 +2,4 @@ puppetlabs.cthun.broker-service/broker-service
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.cthun.authorization.basic-service/authorization-service

--- a/test/puppetlabs/cthun/authorization/basic_core_test.clj
+++ b/test/puppetlabs/cthun/authorization/basic_core_test.clj
@@ -1,0 +1,54 @@
+(ns puppetlabs.cthun.authorization.basic-core-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.cthun.authorization.basic-core :refer :all]
+            [puppetlabs.cthun.message :as message]
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]))
+
+(deftest rule-matches?-test
+  (testing "simplest matcher"
+    (let [message (-> (message/make-message)
+                      (assoc :sender "cth://maverick/pilot"
+                             :message_type "cheque"))
+          rule-matches? (fn [rule message] (rule-matches? (assoc rule :action :allow) message))]
+      (is (= true  (rule-matches? {} message)))
+      (is (= true  (rule-matches? {:sender "maverick"} message)))
+      (is (= true  (rule-matches? {:message_type "cheque"} message)))
+      (is (= false (rule-matches? {:sender "goose"} message)))
+      (is (= false (rule-matches? {:message_type "cashable"} message)))
+      (is (= true  (rule-matches? {:sender "maverick" :message_type "cheque"} message)))
+      (is (= false (rule-matches? {:sender "maverick" :message_type "cashable"} message)))
+      (is (= false (rule-matches? {:sender "goose"    :message_type "cheque"} message)))
+      (is (= false (rule-matches? {:sender "goose"    :message_type "cashable"} message))))))
+
+(deftest authorized-test
+  (testing "no rules, just table defaults"
+    (let [message (message/make-message)]
+      (is (= true  (authorized {:accept {:default :allow}} message)))
+      (is (= false (authorized {:accept {:default :deny}}  message)))))
+  (testing "loop detection"
+    (with-test-logging
+      (let [message (-> (message/make-message)
+                        (assoc :sender "cth://zz/top"))
+            rules   {:accept {:default :allow
+                              :rules [{:action {:target :accept}}]}}]
+        (is (= false (authorized rules message)))
+        (is (logged? #"^Loop detected in rules " :error)))))
+  (testing "cnc style"
+    (let [rules           {:accept {:default :allow
+                                    :rules [{:message_type "cnc_request"
+                                             :action {:target :cnc_commands}}]}
+                           :cnc_commands {:default :deny
+                                          :rules [{:sender "admin"
+                                                   :action :allow}]}}
+          allow-unrelated (-> (message/make-message)
+                              (assoc :sender "cth://anybody/agent"
+                                     :message_type "random_noise"))
+          allowed-command (-> (message/make-message)
+                              (assoc :sender "cth://admin/run"
+                                     :message_type "cnc_request"))
+          denied-command  (-> (message/make-message)
+                              (assoc :sender "cth://anybody/run"
+                                     :message_type "cnc_request"))]
+      (is (= true  (authorized rules allow-unrelated)))
+      (is (= true  (authorized rules allowed-command)))
+      (is (= false (authorized rules denied-command))))))

--- a/test/puppetlabs/cthun/authorization/basic_service_test.clj
+++ b/test/puppetlabs/cthun/authorization/basic_service_test.clj
@@ -1,0 +1,2 @@
+(ns puppetlabs.cthun.authorization.basic-service-test
+  (:require [puppetlabs.cthun.authorization.basic-service :refer :all]))

--- a/test/puppetlabs/cthun/broker_core_test.clj
+++ b/test/puppetlabs/cthun/broker_core_test.clj
@@ -12,6 +12,7 @@
    :activemq-consumers []
    :record-client      (constantly true)
    :find-clients       (constantly true)
+   :authorized         (constantly true)
    :uri-map            (atom {})
    :connections        (atom {})})
 


### PR DESCRIPTION
Here we add a new AuthorizationService protocol that exposes a
single message-authorizing call.  Then we add a simple config-based
iptables-like plugin which should allow powerful enough rules to
express the basic requirements for Ankeny.
