### PR TITLE
CTH-273 use trapperkeeper webrouting service

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -1,4 +1,5 @@
 puppetlabs.cthun.broker-service/broker-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
 puppetlabs.cthun.authorization.basic-service/authorization-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service

--- a/ezbake/config/conf.d/cthun.conf
+++ b/ezbake/config/conf.d/cthun.conf
@@ -1,6 +1,4 @@
 cthun: {
-    url-prefix = /cthun
-
     # Spool used by the queuing service
     broker-spool = /opt/puppetlabs/server/data/cthun
 

--- a/ezbake/config/conf.d/web-router.conf
+++ b/ezbake/config/conf.d/web-router.conf
@@ -1,0 +1,6 @@
+web-router-service: {
+    "puppetlabs.cthun.broker-service/broker-service": {
+        websocket: "/cthun"
+        metrics:   "/"
+    }
+}

--- a/src/puppetlabs/cthun/broker_core.clj
+++ b/src/puppetlabs/cthun/broker_core.clj
@@ -377,8 +377,7 @@
 
 ;; service lifecycle
 (def InitOptions
-  {:path s/Str
-   :activemq-spool s/Str
+  {:activemq-spool s/Str
    :accept-consumers s/Num
    :delivery-consumers s/Num
    :add-ring-handler IFn
@@ -402,8 +401,8 @@
                               :uri-map            (atom {})}
           activemq-consumers (subscribe-to-queues broker accept-consumers delivery-consumers)
           broker             (assoc broker :activemq-consumers activemq-consumers)]
-      (add-ring-handler metrics-app "/")
-      (add-websocket-handler (build-websocket-handlers broker) path)
+      (add-ring-handler metrics-app {:route-id :metrics})
+      (add-websocket-handler (build-websocket-handlers broker) {:route-id :websocket})
       broker)))
 
 (s/defn ^:always-validate start

--- a/src/puppetlabs/cthun/broker_service.clj
+++ b/src/puppetlabs/cthun/broker_service.clj
@@ -6,21 +6,19 @@
 
 (trapperkeeper/defservice broker-service
   [[:ConfigService get-in-config]
-   [:WebserverService add-ring-handler add-websocket-handler]
+   [:WebroutingService add-ring-handler add-websocket-handler]
    [:InventoryService record-client find-clients]
    [:AuthorizationService authorized]]
   (init [this context]
         (log/info "Initializing broker service")
-        (let [path               (get-in-config [:cthun :url-prefix] "/cthun")
-              activemq-spool     (get-in-config [:cthun :broker-spool])
+        (let [activemq-spool     (get-in-config [:cthun :broker-spool])
               accept-consumers   (get-in-config [:cthun :accept-consumers] 4)
               delivery-consumers (get-in-config [:cthun :delivery-consumers] 16)
-              broker             (core/init {:path path
-                                             :activemq-spool activemq-spool
+              broker             (core/init {:activemq-spool activemq-spool
                                              :accept-consumers accept-consumers
                                              :delivery-consumers delivery-consumers
-                                             :add-ring-handler add-ring-handler
-                                             :add-websocket-handler add-websocket-handler
+                                             :add-ring-handler (partial add-ring-handler this)
+                                             :add-websocket-handler (partial add-websocket-handler this)
                                              :record-client record-client
                                              :find-clients find-clients
                                              :authorized authorized})]

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -1,5 +1,6 @@
 puppetlabs.cthun.broker-service/broker-service
 puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.cthun.authorization.basic-service/authorization-service

--- a/test-resources/conf.d/cthun.conf
+++ b/test-resources/conf.d/cthun.conf
@@ -1,6 +1,4 @@
 cthun: {
-    url-prefix = /cthun
-
     ## Spool used by the queuing service
     broker-spool = ./test-resources/tmp/activemq
 

--- a/test-resources/conf.d/web-router.conf
+++ b/test-resources/conf.d/web-router.conf
@@ -1,0 +1,6 @@
+web-router-service: {
+    "puppetlabs.cthun.broker-service/broker-service": {
+        websocket: "/cthun"
+        metrics:   "/"
+    }
+}


### PR DESCRIPTION
Here we change our explicit use of WebserverService to use WebroutingService
and move the configuration that was previously code in the service init out to
configuration.
