### PR TITLE
CTH-26 Use trapperkeeper-metrics for metrics management

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -3,3 +3,4 @@ puppetlabs.cthun.inventory.in-memory/inventory-service
 puppetlabs.cthun.authorization.basic-service/authorization-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service

--- a/ezbake/config/conf.d/metrics.conf
+++ b/ezbake/config/conf.d/metrics.conf
@@ -1,0 +1,16 @@
+metrics: {
+    # needed till version with TK-252 ships
+    enabled: true
+
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+
+    # this section is used to enable/disable JMX reporting
+    reporters: {
+        # enable or disable JMX metrics reporter
+        jmx: {
+            enabled: true
+        }
+    }
+}

--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.4.0"]
+                 [puppetlabs/trapperkeeper-metrics "0.1.1" :exclusions [org.slf4j/slf4j-api]]
 
                  [cheshire "5.5.0"]
                  [prismatic/schema "0.4.3"]

--- a/src/puppetlabs/cthun/broker_service.clj
+++ b/src/puppetlabs/cthun/broker_service.clj
@@ -8,7 +8,8 @@
   [[:ConfigService get-in-config]
    [:WebroutingService add-ring-handler add-websocket-handler]
    [:InventoryService record-client find-clients]
-   [:AuthorizationService authorized]]
+   [:AuthorizationService authorized]
+   [:MetricsService get-metrics-registry]]
   (init [this context]
         (log/info "Initializing broker service")
         (let [activemq-spool     (get-in-config [:cthun :broker-spool])
@@ -21,7 +22,8 @@
                                              :add-websocket-handler (partial add-websocket-handler this)
                                              :record-client record-client
                                              :find-clients find-clients
-                                             :authorized authorized})]
+                                             :authorized authorized
+                                             :get-metrics-registry get-metrics-registry})]
           (assoc context :broker broker)))
   (start [this context]
          (log/info "Starting broker service")

--- a/src/puppetlabs/cthun/metrics.clj
+++ b/src/puppetlabs/cthun/metrics.clj
@@ -1,35 +1,22 @@
 (ns puppetlabs.cthun.metrics
-  (:require [clojure.tools.logging :as log]
-            [clojure.java.jmx :as jmx]
-            [clj-time.core :as time]
-            [metrics.core]
+  (:require [clojure.java.jmx :as jmx]
             [metrics.counters :as counters]
             [metrics.meters :as meters]
             [metrics.timers :as timers]
             [cheshire.core :as cheshire]))
 
-(def total-messages-in (counters/counter ["puppetlabs.cthun" "global" "total-messages-in"]))
-(def total-messages-out (counters/counter ["puppetlabs.cthun" "global" "total-messages-out"]))
-(def active-connections (counters/counter ["puppetlabs.cthun" "global" "active-connections"]))
-(def rate-messages-in (meters/meter ["puppetlabs.cthun" "global" "rate-messages-in"]))
-(def rate-messages-out (meters/meter ["puppetlabs.cthun" "global" "rate-messages-out"]))
-(def time-in-on-connect (timers/timer ["puppetlabs.cthun" "handlers" "time-in-on-connect"]))
-(def time-in-on-text (timers/timer ["puppetlabs.cthun" "handlers" "time-in-on-text"]))
-(def time-in-on-close (timers/timer ["puppetlabs.cthun" "handlers" "time-in-on-close"]))
-(def time-in-message-queueing (timers/timer ["puppetlabs.cthun" "global" "time-in-message-queueing"]))
-
 (defn- get-cthun-metrics
   "Returns cthun specific metrics as a map"
-  []
+  [registry]
   (reduce into {}
-          [(map (fn [[k v]] {k (meters/rates v)}) (.getMeters metrics.core/default-registry))
-           (map (fn [[k v]] {k (counters/value v)}) (.getCounters metrics.core/default-registry))
+          [(map (fn [[k v]] {k (meters/rates v)}) (.getMeters registry))
+           (map (fn [[k v]] {k (counters/value v)}) (.getCounters registry))
            (map (fn [[k v]] {k {:rates (timers/rates v)
                                 :mean (timers/mean v)
                                 :std-dev (timers/std-dev v)
                                 :percentiles (timers/percentiles v)
                                 :largest (timers/largest v)
-                                :smallest (timers/smallest v)} }) (.getTimers metrics.core/default-registry))]))
+                                :smallest (timers/smallest v)} }) (.getTimers registry))]))
 
 (defn- get-memory-metrics
   "Returns memory related metrics as a map"
@@ -42,10 +29,10 @@
   (apply dissoc (jmx/mbean "java.lang:type=Threading") [:ObjectName :AllThreadIds]))
 
 ; TODO(ploubser): Flesh this out
-(defn get-metrics-string
+(defn render-metrics
   "Returns some clean jmx metrics as a json string"
-  []
+  [registry]
   (cheshire/generate-string (-> (assoc {} :memory (get-memory-metrics))
                                 (assoc :threads (get-thread-metrics))
-                                (assoc :cthun (get-cthun-metrics)))
+                                (assoc :cthun (get-cthun-metrics registry)))
                             {:pretty true}))

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -3,4 +3,5 @@ puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
 puppetlabs.cthun.inventory.in-memory/inventory-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.cthun.authorization.basic-service/authorization-service

--- a/test-resources/conf.d/metrics.conf
+++ b/test-resources/conf.d/metrics.conf
@@ -1,0 +1,16 @@
+metrics: {
+    # needed till version with TK-252 ships
+    enabled: true
+
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+
+    # this section is used to enable/disable JMX reporting
+    reporters: {
+        # enable or disable JMX metrics reporter
+        jmx: {
+            enabled: true
+        }
+    }
+}

--- a/test/puppetlabs/cthun/broker_core_test.clj
+++ b/test/puppetlabs/cthun/broker_core_test.clj
@@ -14,7 +14,9 @@
    :find-clients       (constantly true)
    :authorized         (constantly true)
    :uri-map            (atom {})
-   :connections        (atom {})})
+   :connections        (atom {})
+   :metrics-registry   ""
+   :metrics            {}})
 
 (deftest new-socket-test
   (testing "It returns a map that matches represents a new socket"


### PR DESCRIPTION
Here we switch to using trapperkeeper-metrics and move the metrics
we are using into the context of the broker.
- remove global metric vars
- rename and rationalise some metrics (Timers are also Meters and Counters, so
  we don't need as many discrete metrics)
- ensure that all message queueing is covered by
  puppetlabs.cthun.message-queuing
