### PR TITLE
(maint) bump version to 0.2.0-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def tk-version "1.1.1")
 (def ks-version "1.1.0")
-(def cthun-version "0.1.0-SNAPSHOT")
+(def cthun-version "0.2.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
With the recent commits the names of tk services we consume is radically
different, so burn a 0.Y to reflect that
