### PR TITLE
CTH-316 Fix websockets close behaviour

### DIFF
--- a/test/puppetlabs/cthun/broker/core_test.clj
+++ b/test/puppetlabs/cthun/broker/core_test.clj
@@ -97,8 +97,8 @@
     (is (= [ "*" "agent" ] (explode-uri "cth://*/agent")))))
 
 (deftest process-session-association-message-test
-  (with-redefs [puppetlabs.experimental.websockets.client/close! (fn [ws] false)
-                puppetlabs.experimental.websockets.client/send! (fn [ws bytes] false)]
+  (with-redefs [puppetlabs.experimental.websockets.client/close! (constantly false)
+                puppetlabs.experimental.websockets.client/send! (constantly false)]
     (let [message (-> (message/make-message)
                       (assoc  :sender "cth://localhost/controller"
                               :message_type "http://puppetlabs.com/login_message"))]


### PR DESCRIPTION
Here we work-around TK-270 by always supplying a reason for shutting down the
socket.

We should ratify these close codes in the PCP specificationi at some later date.
