### PR TITLE
CTH-327 Fix the delivery behaviour for explicit disconnected targets

### DIFF
--- a/test/puppetlabs/cthun/broker/core_test.clj
+++ b/test/puppetlabs/cthun/broker/core_test.clj
@@ -18,6 +18,19 @@
    :metrics-registry   ""
    :metrics            {}})
 
+(deftest explode-uri-test
+  (testing "It raises on invalid uris"
+    (is (thrown? Exception (explode-uri ""))))
+  (testing "It returns component chunks"
+    (is (= [ "localhost" "agent"] (explode-uri "cth://localhost/agent")))
+    (is (= [ "localhost" "*" ] (explode-uri "cth://localhost/*")))
+    (is (= [ "*" "agent" ] (explode-uri "cth://*/agent")))))
+
+(deftest uri-wildcard?-test
+  (is (= true  (uri-wildcard? "cth://*/agent")))
+  (is (= true  (uri-wildcard? "cth://agent01.example.com/*")))
+  (is (= false (uri-wildcard? "cth://agent01.example.com/agent"))))
+
 (deftest new-socket-test
   (testing "It returns a map that matches represents a new socket"
     (let [socket (new-socket)]
@@ -87,14 +100,6 @@
                       (assoc :targets ["cth://other/server"]
                              :message_type "http://puppetlabs.com/associate_request"))]
       (is (= false (session-association-message? message))))))
-
-(deftest explode-uri-test
-  (testing "It raises on invalid uris"
-    (is (thrown? Exception (explode-uri ""))))
-  (testing "It returns component chunks"
-    (is (= [ "localhost" "agent"] (explode-uri "cth://localhost/agent")))
-    (is (= [ "localhost" "*" ] (explode-uri "cth://localhost/*")))
-    (is (= [ "*" "agent" ] (explode-uri "cth://*/agent")))))
 
 (deftest process-session-association-message-test
   (with-redefs [puppetlabs.experimental.websockets.client/close! (constantly false)


### PR DESCRIPTION
Here we change the interaction of message destination routing a
little.  Previously in order to send a message to a client directly
by Uri it would needed to have made itself known with the broker
via session association (which registered it with the inventory),
which mean a message directly to a client that had never connected
would never be delivered.

Now we more closely inspect the targets of a message, if no wildcard
is detected in the Uri then we treat it as an explicit address and
will enqueue a message for delivery to it, wildcards are still
resolved via the inventory service.
