### PR TITLE
CTH-328 track message state

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/cthun-message "0.1.0"]
+                 [puppetlabs/cthun-message "0.2.0"]
 
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4" :exclusions [org.slf4j/slf4j-api]]

--- a/src/puppetlabs/cthun/broker/capsule.clj
+++ b/src/puppetlabs/cthun/broker/capsule.clj
@@ -43,9 +43,7 @@
   [capsule :- Capsule]
   (let [message (:message capsule)
         hops    (:hops capsule)]
-    ;; TODO(richardc) this should really be
-    ;; (message/append-debug-json message {:hops hops})
-    (message/encode (assoc message :_hops hops))))
+    (message/encode (message/set-json-debug message {:hops hops}))))
 
 (s/defn ^:always-validate wrap :- Capsule
   "Wrap a Message producing a Capsule"

--- a/src/puppetlabs/cthun/broker/core.clj
+++ b/src/puppetlabs/cthun/broker/core.clj
@@ -137,8 +137,7 @@
   (let [message (:message capsule)
         response_data {:id (:id message)}
         response (-> (message/make-message)
-                     (assoc :id           (ks/uuid)
-                            :message_type "http://puppetlabs.com/ttl_expired"
+                     (assoc :message_type "http://puppetlabs.com/ttl_expired"
                             :targets      [(:sender message)]
                             :sender       "cth:///server")
                      (message/set-expiry 3 :seconds)
@@ -170,8 +169,7 @@
     (let [report {:id (:id message)
                   :targets targets}
           reply (-> (message/make-message)
-                    (assoc :id (ks/uuid)
-                           :targets [(:sender message)]
+                    (assoc :targets [(:sender message)]
                            :message_type "http://puppetlabs.com/destination_report"
                            :sender "cth:///server")
                     (message/set-expiry 3 :seconds)
@@ -258,8 +256,7 @@
                         (association-response broker ws request))]
     (s/validate schemas/AssociateResponse response)
     (let [message (-> (message/make-message)
-                      (assoc :id (ks/uuid)
-                             :message_type "http://puppetlabs.com/associate_response"
+                      (assoc :message_type "http://puppetlabs.com/associate_response"
                              :targets [ (:sender request) ]
                              :sender "cth:///server")
                       (message/set-expiry 3 :seconds)
@@ -278,8 +275,7 @@
     (let [uris ((:find-clients broker) (:query data))
           response-data {:uris uris}
           response (-> (message/make-message)
-                       (assoc :id (ks/uuid)
-                              :message_type "http://puppetlabs.com/inventory_response"
+                       (assoc :message_type "http://puppetlabs.com/inventory_response"
                               :targets [(:sender message)]
                               :sender "cth:///server")
                        (message/set-expiry 3 :seconds)

--- a/test/puppetlabs/cthun/broker/core_test.clj
+++ b/test/puppetlabs/cthun/broker/core_test.clj
@@ -75,15 +75,14 @@
   (with-redefs [accept-message-for-delivery (fn [broker response] response)]
     (testing "It will create and send a ttl expired message"
       (let [expired (-> (message/make-message)
-                        (assoc :id "12347890"
-                               :sender "cth://client2.com/tester"))
+                        (assoc :sender "cth://client2.com/tester"))
             broker (make-test-broker)
             capsule (process-expired-message broker (capsule/wrap expired))
             response (:message capsule)
             response-data (message/get-json-data response)]
         (is (= ["cth://client2.com/tester"] (:targets response)))
         (is (= "http://puppetlabs.com/ttl_expired" (:message_type response)))
-        (is (= "12347890" (:id response-data)))))))
+        (is (= (:id expired) (:id response-data)))))))
 
 (deftest session-association-message?-test
   (testing "It returns true when passed a sessions association messge"

--- a/test/puppetlabs/cthun/broker/service_test.clj
+++ b/test/puppetlabs/cthun/broker/service_test.clj
@@ -107,8 +107,7 @@
     broker-config
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [request (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :message_type "http://puppetlabs.com/inventory_request"
+                        (assoc :message_type "http://puppetlabs.com/inventory_request"
                                :targets ["cth:///server"]
                                :sender "cth://client01.example.com/test")
                         (message/set-expiry 3 :seconds)
@@ -125,8 +124,7 @@
     broker-config
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [request (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :message_type "http://puppetlabs.com/inventory_request"
+                        (assoc :message_type "http://puppetlabs.com/inventory_request"
                                :targets ["cth:///server"]
                                :sender "cth://client01.example.com/test")
                         (message/set-expiry 3 :seconds)
@@ -144,8 +142,7 @@
     (with-open [client (client/connect "client02.example.com" "cth://client02.example.com/test" true)])
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [request (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :message_type "http://puppetlabs.com/inventory_request"
+                        (assoc :message_type "http://puppetlabs.com/inventory_request"
                                :targets ["cth:///server"]
                                :sender "cth://client01.example.com/test")
                         (message/set-expiry 3 :seconds)
@@ -163,8 +160,7 @@
     broker-config
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [message (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :sender "cth://client01.example.com/test"
+                        (assoc :sender "cth://client01.example.com/test"
                                :targets ["cth://client01.example.com/test"]
                                :message_type "greeting")
                         (message/set-expiry 3 :seconds)
@@ -181,8 +177,7 @@
     broker-config
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [message (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :sender "cth://client01.example.com/test"
+                        (assoc :sender "cth://client01.example.com/test"
                                :targets ["cth://*/test"]
                                :message_type "greeting")
                         (message/set-expiry 3 :seconds)
@@ -200,8 +195,7 @@
     (with-open [sender   (client/connect "client01.example.com" "cth://client01.example.com/test" true)
                 receiver (client/connect "client02.example.com" "cth://client02.example.com/test" true)]
       (let [message (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :sender "cth://client01.example.com/test"
+                        (assoc :sender "cth://client01.example.com/test"
                                :targets ["cth://client02.example.com/test"]
                                :destination_report true
                                :message_type "greeting")
@@ -224,8 +218,7 @@
     broker-config
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [message (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :sender "cth://client01.example.com/test"
+                        (assoc :sender "cth://client01.example.com/test"
                                :targets ["cth://client02.example.com/*"]
                                :message_type "greeting")
                         (message/set-expiry 3 :seconds)
@@ -242,8 +235,7 @@
     broker-config
     (with-open [client (client/connect "client01.example.com" "cth://client01.example.com/test" true)]
       (let [message (-> (message/make-message)
-                        (assoc :id (ks/uuid)
-                               :sender "cth://client01.example.com/test"
+                        (assoc :sender "cth://client01.example.com/test"
                                :targets ["cth://client02.example.com/test"]
                                :message_type "greeting")
                         (message/set-expiry 3 :seconds)

--- a/test/puppetlabs/cthun/testutils/client.clj
+++ b/test/puppetlabs/cthun/testutils/client.clj
@@ -38,8 +38,7 @@
 (defn make-association-request
   [uri]
   (-> (message/make-message)
-      (assoc :id (ks/uuid)
-             :message_type "http://puppetlabs.com/associate_request"
+      (assoc :message_type "http://puppetlabs.com/associate_request"
              :targets ["cth:///server"]
              :sender uri)
       (message/set-expiry 3 :seconds)))


### PR DESCRIPTION
Here we add a new schema Capsule that holds the state of a Message as it moves through the broker.  This is the correct home of what was previously side-banded into Message as :_target and :_hops which were remnants of a hasty extraction as part of CTH-185/CTH-187.
