### PR TITLE
(maint) Add dev-resources directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 *~
 /.idea
 /test-resources/tmp/
+/dev-resources/


### PR DESCRIPTION
It is useful to have an ignored directory to store, for example
local configuration and certificate files.
