### PR TITLE
(maint) Add in-reply-to to inventory_responses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/cthun-message "0.3.0"]
+                 [puppetlabs/cthun-message "0.3.1"]
 
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4"]

--- a/src/puppetlabs/cthun/broker/core.clj
+++ b/src/puppetlabs/cthun/broker/core.clj
@@ -265,6 +265,7 @@
           response (-> (message/make-message)
                        (assoc :message_type "http://puppetlabs.com/inventory_response"
                               :targets [(:sender message)]
+                              :in-reply-to (:id message)
                               :sender "cth:///server")
                        (message/set-expiry 3 :seconds)
                        (message/set-json-data response-data))]


### PR DESCRIPTION
As an experimental change to the protocol, use in-reply-to when sending an
inventory_response
