### PR TITLE
(maint) tidy up requires for activemq

### DIFF
--- a/src/puppetlabs/cthun/broker/activemq.clj
+++ b/src/puppetlabs/cthun/broker/activemq.clj
@@ -1,10 +1,9 @@
 (ns puppetlabs.cthun.broker.activemq
-  (:require [clojure.edn :as edn]
-            [taoensso.nippy :as nippy]
-            [puppetlabs.puppetdb.mq :as mq]
+  (:require [clamq.protocol.connection :as mq-conn]
             [clamq.protocol.consumer :as mq-cons]
-            [clamq.protocol.connection :as mq-conn]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [puppetlabs.puppetdb.mq :as mq]
+            [taoensso.nippy :as nippy]))
 
 ;; This is a bit rude/lazy, reaching right into puppetdb sources we've
 ;; copied into our tree.  If this proves out we should talk to


### PR DESCRIPTION
Remove the unused require of clojure.edn, and sort other requires to be
alphabetic.  Some combination of these was inhibiting loading all the
namespaces via cider-test.
