### PR TITLE
(CTH-351) Finish starting when start function returns

### DIFF
--- a/src/puppetlabs/pcp/broker/activemq.clj
+++ b/src/puppetlabs/pcp/broker/activemq.clj
@@ -21,7 +21,7 @@
 (defn subscribe-to-queue
   [queue callback-fn consumer-count]
   (let [mq-spec "vm://localhost?create=false"]
-    (with-open [conn (mq/activemq-connection mq-spec)]
+    (let [conn (mq/activemq-connection mq-spec)]
       (doall (for [i (range consumer-count)]
                (let [consumer (mq-conn/consumer conn
                                                 {:endpoint   queue

--- a/test/puppetlabs/pcp/broker/core_test.clj
+++ b/test/puppetlabs/pcp/broker/core_test.clj
@@ -10,7 +10,9 @@
   "Return a minimal clean broker state"
   []
   {:activemq-broker    "JMSOMGBBQ"
-   :activemq-consumers []
+   :accept-consumers   2
+   :delivery-consumers 2
+   :activemq-consumers (atom [])
    :record-client      (constantly true)
    :find-clients       (constantly true)
    :authorized         (constantly true)


### PR DESCRIPTION
In the past, when the start function returned, the pcp-broker wasn't in
a fully started state. This was due to two reasons.

Firstly we were creating our subscriptions to the broker in a with-open
block. When the close function was implicitly called and the connection
was terminated the consumers had to try and get another connection and
this would happen after the start function returned.

Secondly, the consumers were created before the activemq broker's start
function was called. This meant that they couldn't start up immediately
and again could only start after the broker's start function returned.

Here we change the subscribe-to-queue function to create the consumers
in a let block instead of with-open, keeping the connection open.

Now we also wait for the activemq broker to start before starting up the
consumers.
