### PR TITLE
DO NOT MERGE (CTH-134) Message hops should include the server identity

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -13,6 +13,7 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.metrics :refer [time!]]
             [puppetlabs.puppetdb.mq :as mq]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.core :as s]
             [slingshot.slingshot :refer [throw+ try+]])
   (:import (clojure.lang IFn Atom)))
@@ -52,7 +53,8 @@
    :connections        Atom ;; atom with schema Connections. will be checked with :validator
    :metrics-registry   Object
    :metrics            {s/Keyword Object}
-   :transitions        {ConnectionState IFn}})
+   :transitions        {ConnectionState IFn}
+   :broker-cn          s/Str})
 
 ;; Metrics
 (s/defn metrics-app
@@ -77,10 +79,14 @@
 
 (def delivery-queue "delivery")
 
+(s/defn ^:always-validate get-broker-cn :- s/Str
+  [certificate :- s/Str]
+  (let [x509     (ssl-utils/pem->cert certificate)]
+    (ssl-utils/get-cn-from-x509-certificate x509)))
+
 (s/defn ^:always-validate broker-uri :- p/Uri
   [broker :- Broker]
-  ;; TODO(richardc) should come from config or the cert of this instance
-  "pcp:///server")
+  (str "pcp://" (:broker-cn broker)"/server"))
 
 ;; connection lifecycle
 (s/defn ^:always-validate make-connection :- Connection
@@ -429,13 +435,14 @@
    :record-client IFn
    :find-clients IFn
    :authorized IFn
-   :get-metrics-registry IFn})
+   :get-metrics-registry IFn
+   :ssl-cert s/Str})
 
 (s/defn ^:always-validate init :- Broker
   [options :- InitOptions]
   (let [{:keys [path activemq-spool accept-consumers delivery-consumers
                 add-ring-handler add-websocket-handler
-                record-client find-clients authorized get-metrics-registry]} options]
+                record-client find-clients authorized get-metrics-registry ssl-cert]} options]
     (let [activemq-broker    (mq/build-embedded-broker activemq-spool)
           broker             {:activemq-broker    activemq-broker
                               :accept-consumers   accept-consumers
@@ -449,7 +456,8 @@
                               :connections        (atom {} :validator (partial s/validate Connections))
                               :uri-map            (atom {} :validator (partial s/validate UriMap))
                               :transitions        {:open connection-open
-                                                   :associated connection-associated}}
+                                                   :associated connection-associated}
+                              :broker-cn          (get-broker-cn ssl-cert)}
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
       (add-ring-handler (partial metrics-app broker) {:route-id :metrics})

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -8,7 +8,7 @@
 
 (trapperkeeper/defservice broker-service
   [[:ConfigService get-in-config]
-   [:WebroutingService add-ring-handler add-websocket-handler]
+   [:WebroutingService add-ring-handler add-websocket-handler get-server]
    [:MetricsService get-metrics-registry]]
   (init [this context]
     (log/info "Initializing broker service")
@@ -17,6 +17,7 @@
           delivery-consumers (get-in-config [:pcp-broker :delivery-consumers] 16)
           authorization      (get-in-config [:pcp-broker :authorization] {:accept {:default :allow}})
           inventory          (make-inventory)
+          ssl-cert    (get-in-config [:webserver (keyword (get-server this :websocket)) :ssl-cert])
           broker             (core/init {:activemq-spool activemq-spool
                                          :accept-consumers accept-consumers
                                          :delivery-consumers delivery-consumers
@@ -25,7 +26,8 @@
                                          :record-client  (partial record-client inventory)
                                          :find-clients   (partial find-clients inventory)
                                          :authorized (partial authz/authorized authorization)
-                                         :get-metrics-registry get-metrics-registry})]
+                                         :get-metrics-registry get-metrics-registry
+                                         :ssl-cert ssl-cert})]
       (assoc context :broker broker)))
   (start [this context]
     (log/info "Starting broker service")

--- a/test-resources/conf.d/web-router.conf
+++ b/test-resources/conf.d/web-router.conf
@@ -1,6 +1,12 @@
 web-router-service: {
     "puppetlabs.pcp.broker.service/broker-service": {
-        websocket: "/pcp"
-        metrics:   "/"
+        websocket: {
+          route: "/pcp"
+          server: "pcp-broker"
+        }
+        metrics: {
+          route: "/"
+          server: "pcp-broker"
+        }
     }
 }

--- a/test-resources/conf.d/webserver.conf
+++ b/test-resources/conf.d/webserver.conf
@@ -1,9 +1,11 @@
 webserver: {
-    client-auth = want
-    ssl-host    = 0.0.0.0
-    ssl-port    = 8090
-    ssl-key     = ./test-resources/ssl/private_keys/broker.example.com.pem
-    ssl-cert    = ./test-resources/ssl/certs/broker.example.com.pem
-    ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem
-    ssl-crl-path = ./test-resources/ssl/ca/ca_crl.pem
+    pcp-broker {
+        client-auth = want
+        ssl-host    = 0.0.0.0
+        ssl-port    = 8090
+        ssl-key     = ./test-resources/ssl/private_keys/broker.example.com.pem
+        ssl-cert    = ./test-resources/ssl/certs/broker.example.com.pem
+        ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem
+        ssl-crl-path = ./test-resources/ssl/ca/ca_crl.pem
+    }
 }

--- a/test/puppetlabs/pcp/broker/core_test.clj
+++ b/test/puppetlabs/pcp/broker/core_test.clj
@@ -20,7 +20,13 @@
    :connections        (atom {})
    :metrics-registry   ""
    :metrics            {}
-   :transitions        {}})
+   :transitions        {}
+   :broker-cn          "broker.example.com"})
+
+(deftest get-broker-cn-test
+  (testing "It returns the correct cn"
+    (let [cn (get-broker-cn "./test-resources/ssl/certs/broker.example.com.pem")]
+      (is (= "broker.example.com" cn)))))
 
 (deftest make-connection-test
   (testing "It returns a map that matches represents a new socket"

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -16,17 +16,19 @@
 
 (def broker-config
   "A broker with ssl and own spool"
-  {:webserver {:ssl-host "127.0.0.1"
-               :ssl-port 8081
-               :client-auth "want"
-               :ssl-key "./test-resources/ssl/private_keys/broker.example.com.pem"
-               :ssl-cert "./test-resources/ssl/certs/broker.example.com.pem"
-               :ssl-ca-cert "./test-resources/ssl/ca/ca_crt.pem"
-               :ssl-crl-path "./test-resources/ssl/ca/ca_crl.pem"}
+  {:webserver {:pcp-broker {:ssl-host "127.0.0.1"
+                            :ssl-port 8081
+                            :client-auth "want"
+                            :ssl-key "./test-resources/ssl/private_keys/broker.example.com.pem"
+                            :ssl-cert "./test-resources/ssl/certs/broker.example.com.pem"
+                            :ssl-ca-cert "./test-resources/ssl/ca/ca_crt.pem"
+                            :ssl-crl-path "./test-resources/ssl/ca/ca_crl.pem"}}
 
    :web-router-service
-   {:puppetlabs.pcp.broker.service/broker-service {:websocket "/pcp"
-                                                   :metrics "/"}}
+   {:puppetlabs.pcp.broker.service/broker-service {:websocket {:route "/pcp"
+                                                               :server "pcp-broker"}
+                                                   :metrics {:route "/"
+                                                             :server "pcp-broker"}}}
 
    :metrics {:enabled true}
 


### PR DESCRIPTION
In the past the server URI was hardcoded to be pcp:///server, the URI
used by clients when addressing the server.

Here we update the broker-uri fn to return the correct server URI based
on the cn in it's ssl-certificate.

This relies on a `get-server` function to be added to
trapperkeeper-jetty9's webrouting service. This allows us to get the
server name from the current context and look up the corresponding
ssl-certificate file and extract the cn from there.

As a result the default web-router.conf webserver.conf files changed to include
the server name.