### PR TITLE
(maint) change default port to 8142

### DIFF
--- a/test-resources/conf.d/webserver.conf
+++ b/test-resources/conf.d/webserver.conf
@@ -1,7 +1,7 @@
 webserver: {
     client-auth = want
     ssl-host    = 0.0.0.0
-    ssl-port    = 8090
+    ssl-port    = 8142
     ssl-key     = ./test-resources/ssl/private_keys/broker.example.com.pem
     ssl-cert    = ./test-resources/ssl/certs/broker.example.com.pem
     ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -17,7 +17,10 @@
 (def broker-config
   "A broker with ssl and own spool"
   {:webserver {:ssl-host "127.0.0.1"
-               :ssl-port 8081
+               ;; usual port is 8142.  Here we use 8143 so if we're developing
+               ;; we can run a long-running instance and this one for the
+               ;; tests.
+               :ssl-port 8143
                :client-auth "want"
                :ssl-key "./test-resources/ssl/private_keys/broker.example.com.pem"
                :ssl-cert "./test-resources/ssl/certs/broker.example.com.pem"
@@ -50,7 +53,7 @@
     (let [connected (promise)]
       (with-open [client (client/http-client-with-cert "client01.example.com")
                   ws     (http/websocket client
-                                         "wss://127.0.0.1:8081/pcp"
+                                         "wss://127.0.0.1:8143/pcp"
                                          :open (fn [ws] (deliver connected true)))]
         (is (= true (deref connected (* 2 1000) false)) "Connected within 2 seconds")))))
 

--- a/test/puppetlabs/pcp/testutils/client.clj
+++ b/test/puppetlabs/pcp/testutils/client.clj
@@ -49,7 +49,7 @@
   (let [association-request (make-association-request identity)
         client              (http-client-with-cert certname)
         message-chan        (chan)
-        ws                  (http/websocket client "wss://127.0.0.1:8081/pcp"
+        ws                  (http/websocket client "wss://127.0.0.1:8143/pcp"
                                             :open  (fn [ws]
                                                      (http/send ws :byte (message/encode association-request)))
                                             :byte  (fn [ws msg]


### PR DESCRIPTION
During development we were setting up our test brokers on port 8080 and 8090
(non-ssl and ssl).  Now the 'production' port will be, for a time, 8142.
Update the sample config to use 8142 and the tests to use 8143 (so we can run a
sample server and the tests concurrently)