### PR TITLE
Prepare for the 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.2.2
+
+This is a bugfix release.
+
+* [CTH-351](https://tickets.puppetlabs.com/browse/CTH-351) Fix broker startup
+  to always start a working broker.
+* Adopt cljfmt style guide from https://github.com/puppetlabs/pl-clojure-style
+* Relicence to APL 2.0 (from internal commercial)


### PR DESCRIPTION
Here we add a CHANGELOG.md and document the difference between 0.2.1
and 0.2.2.