### PR TITLE
(maint) prepare to be an open project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Third-party patches are essential for keeping puppet open-source projects
+great. We want to keep it as easy as possible to contribute changes that
+allow you to get the most out of our projects. There are a few guidelines
+that we need contributors to follow so that we can have a chance of keeping on
+top of things.  For more info, see our canonical guide to contributing:
+
+[https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ following command:
 ## Documentation
 
 Look [here](docs/).
+
+## Support
+
+We use the [Puppet Communications Protocol project on JIRA](https://tickets.puppetlabs.com/browse/PCP)
+with the component `pcp-broker` for tickets on `puppetlabs/pcp-broker`.


### PR DESCRIPTION
Here we add a CONTRIBUTING.md, a forward reference to our issue tracker to the
README.md, and make the CHANGELOG.md follow the same format as that established
by trapperkeeper-webserver-jetty9 in preparation of being an official
PuppetLabs open library.