### PR TITLE
(CTH-134) Message hops should include the server identity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.4.0"]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.0"]
                  [puppetlabs/trapperkeeper-metrics "0.1.1"]
 
                  [cheshire "5.5.0"]

--- a/test/puppetlabs/pcp/broker/core_test.clj
+++ b/test/puppetlabs/pcp/broker/core_test.clj
@@ -20,7 +20,13 @@
    :connections        (atom {})
    :metrics-registry   ""
    :metrics            {}
-   :transitions        {}})
+   :transitions        {}
+   :broker-cn          "broker.example.com"})
+
+(deftest get-broker-cn-test
+  (testing "It returns the correct cn"
+    (let [cn (get-broker-cn "./test-resources/ssl/certs/broker.example.com.pem")]
+      (is (= "broker.example.com" cn)))))
 
 (deftest make-connection-test
   (testing "It returns a map that matches represents a new socket"

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -252,8 +252,8 @@
           (is (= {:id (:id message)} (message/get-json-data response))))))))
 
 (deftest send-disconnect-connect-receive
-  (with-app-with-config
-   app
+ (with-app-with-config
+  app
    [broker-service jetty9-service webrouting-service metrics-service]
    broker-config
    (with-open [client (client/connect "client01.example.com" "pcp://client01.example.com/test" true)]

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -252,19 +252,19 @@
           (is (= {:id (:id message)} (message/get-json-data response))))))))
 
 (deftest send-disconnect-connect-receive
- (with-app-with-config
-  app
-   [broker-service jetty9-service webrouting-service metrics-service]
-   broker-config
-   (with-open [client (client/connect "client01.example.com" "pcp://client01.example.com/test" true)]
-     (let [message (-> (message/make-message)
-                       (assoc :sender "pcp://client01.example.com/test"
-                              :targets ["pcp://client02.example.com/test"]
-                              :message_type "greeting")
-                       (message/set-expiry 3 :seconds)
-                       (message/set-json-data "Hello"))]
-       (client/send! client message)))
-   (with-open [client (client/connect "client02.example.com" "pcp://client02.example.com/test" true)]
-     (let [message (client/recv! client)]
-       (is (= "Hello" (message/get-json-data message)))))))
+  (with-app-with-config
+    app
+    [broker-service jetty9-service webrouting-service metrics-service]
+    broker-config
+    (with-open [client (client/connect "client01.example.com" "pcp://client01.example.com/test" true)]
+      (let [message (-> (message/make-message)
+                        (assoc :sender "pcp://client01.example.com/test"
+                               :targets ["pcp://client02.example.com/test"]
+                               :message_type "greeting")
+                        (message/set-expiry 3 :seconds)
+                        (message/set-json-data "Hello"))]
+        (client/send! client message)))
+    (with-open [client (client/connect "client02.example.com" "pcp://client02.example.com/test" true)]
+      (let [message (client/recv! client)]
+        (is (= "Hello" (message/get-json-data message)))))))
 


### PR DESCRIPTION
In the past the server URI was hardcoded to be pcp:///server, the URI
used by clients when addressing the server.

Here we update the broker-uri fn to return the correct server URI based
on the cn in it's ssl-certificate. The ssl-cert is determined by looking
up the server value in the :websocket route, or directly from the server
if there is only one configured.