### PR TITLE
PCP-37 Add reference configs to resources/ext for ezbake

### DIFF
--- a/resources/ext/config/conf.d/metrics.conf
+++ b/resources/ext/config/conf.d/metrics.conf
@@ -1,0 +1,16 @@
+metrics: {
+    # needed till version with TK-252 ships
+    enabled: true
+
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+
+    # this section is used to enable/disable JMX reporting
+    reporters: {
+        # enable or disable JMX metrics reporter
+        jmx: {
+            enabled: true
+        }
+    }
+}

--- a/resources/ext/config/conf.d/pcp-broker.conf
+++ b/resources/ext/config/conf.d/pcp-broker.conf
@@ -1,0 +1,10 @@
+pcp-broker: {
+    ## Spool used by the queuing service
+    broker-spool = /opt/puppetlabs/var/cache/pe-orchestration-services/pcp-broker
+
+    ## Number of consumers for the accept queue.  Default is 4
+    # accept-consumers = 4
+
+    ## Number of consumers for the delivery queue.  Default is 16
+    # delivery-consumers = 16
+}

--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -1,0 +1,12 @@
+web-router-service: {
+  "puppetlabs.pcp.broker.service/broker-service": {
+    websocket: {
+      route: "/pcp"
+      server: "pcp-broker"
+    }
+    metrics: {
+      route: "/"
+      server: "pcp-broker"
+    }
+  }
+}

--- a/resources/ext/config/conf.d/webserver.conf
+++ b/resources/ext/config/conf.d/webserver.conf
@@ -1,0 +1,11 @@
+webserver: {
+  pcp-broker: {
+    ssl-host: 0.0.0.0
+    ssl-port: 8142
+    client-auth: want
+    ssl-cert: /etc/puppetlabs/ssl/certs/localhost.pem
+    ssl-key: /etc/puppetlabs/ssl/private_keys/localhost.pem
+    ssl-ca-cert: /etc/puppetlabs/ssl/ca/ca_crt.pem
+    ssl-crl-path: /etc/puppetlabs/ssl/ca/ca_crl.pem
+  }
+}

--- a/test-resources/conf.d/metrics.conf
+++ b/test-resources/conf.d/metrics.conf
@@ -1,16 +1,1 @@
-metrics: {
-    # needed till version with TK-252 ships
-    enabled: true
-
-    # a server id that will be used as part of the namespace for metrics produced
-    # by this server
-    server-id: localhost
-
-    # this section is used to enable/disable JMX reporting
-    reporters: {
-        # enable or disable JMX metrics reporter
-        jmx: {
-            enabled: true
-        }
-    }
-}
+../../resources/ext/config/conf.d/metrics.conf

--- a/test-resources/conf.d/web-router.conf
+++ b/test-resources/conf.d/web-router.conf
@@ -1,6 +1,0 @@
-web-router-service: {
-    "puppetlabs.pcp.broker.service/broker-service": {
-        websocket: "/pcp"
-        metrics:   "/"
-    }
-}

--- a/test-resources/conf.d/web-routes.conf
+++ b/test-resources/conf.d/web-routes.conf
@@ -1,0 +1,1 @@
+../../resources/ext/config/conf.d/web-routes.conf

--- a/test-resources/conf.d/webserver.conf
+++ b/test-resources/conf.d/webserver.conf
@@ -1,9 +1,11 @@
 webserver: {
-    client-auth = want
-    ssl-host    = 0.0.0.0
-    ssl-port    = 8142
-    ssl-key     = ./test-resources/ssl/private_keys/broker.example.com.pem
-    ssl-cert    = ./test-resources/ssl/certs/broker.example.com.pem
-    ssl-ca-cert = ./test-resources/ssl/ca/ca_crt.pem
-    ssl-crl-path = ./test-resources/ssl/ca/ca_crl.pem
+  pcp-broker: {
+    ssl-host: 0.0.0.0
+    ssl-port: 8142
+    client-auth: want
+    ssl-cert: ./test-resources/ssl/certs/broker.example.com.pem
+    ssl-key: ./test-resources/ssl/private_keys/broker.example.com.pem
+    ssl-ca-cert: ./test-resources/ssl/ca/ca_crt.pem
+    ssl-crl-path: ./test-resources/ssl/ca/ca_crl.pem
+  }
 }


### PR DESCRIPTION
Here we add some reference configurations, based on the previous test-resources
configurations, but ready for consumption by an ezbake built service wrapper.

We have moved from using the default unnamed trapperkeeper webserver to
a named webserver called "pcp-broker", to allow easier integration with other
services that need their own uniquely configured webservers.

Symlinks from the common resources have been added to the test-resources
directory, to reduce duplication where possible.