### PR TITLE
Correct the structure of the fake ring request

### DIFF
--- a/test/puppetlabs/pcp/broker/core_test.clj
+++ b/test/puppetlabs/pcp/broker/core_test.clj
@@ -69,9 +69,13 @@
         (is (= {:uri "/pcp-broker/send"
                 :request-method :post
                 :remote-addr ""
-                :params {:sender "pcp://example01.example.com/agent"
-                         :targets "pcp://example02.example.com/agent"
-                         :message_type "example1"}}
+                :form-params {}
+                :query-params {"sender" "pcp://example01.example.com/agent"
+                               "targets" "pcp://example02.example.com/agent"
+                               "message_type" "example1"}
+                :params {"sender" "pcp://example01.example.com/agent"
+                         "targets" "pcp://example02.example.com/agent"
+                         "message_type" "example1"}}
                (make-ring-request broker capsule)))))
     (testing "it should return a ring request - two targets"
       (let [message (message/make-message :message_type "example1"
@@ -82,10 +86,15 @@
         (is (= {:uri "/pcp-broker/send"
                 :request-method :post
                 :remote-addr ""
-                :params {:sender "pcp://example01.example.com/agent"
-                         :targets ["pcp://example02.example.com/agent"
-                                   "pcp://example03.example.com/agent"]
-                         :message_type "example1"}}
+                :form-params {}
+                :query-params {"sender" "pcp://example01.example.com/agent"
+                               "targets" ["pcp://example02.example.com/agent"
+                                          "pcp://example03.example.com/agent"]
+                               "message_type" "example1"}
+                :params {"sender" "pcp://example01.example.com/agent"
+                         "targets" ["pcp://example02.example.com/agent"
+                                    "pcp://example03.example.com/agent"]
+                         "message_type" "example1"}}
                (make-ring-request broker capsule)))))))
 
 (deftest authorized?-test

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -259,7 +259,7 @@
           ;; destinations
           (is (= {:id (:id message)} (message/get-json-data response))))))))
 
-(deftest send-disconnect-connect-receive
+(deftest send-disconnect-connect-receive-test
   (with-app-with-config
     app
     [authorization-service broker-service jetty9-service webrouting-service metrics-service]


### PR DESCRIPTION
The structure of the query-params to a ring request is {String String}.  Previously we were supplying {:keyword String}, which meant trapperkeeper-authorization was not able to correctly match on query-params.
