### PR TITLE
PCP-115 Convert logging to structured-logging, and reword

### DIFF
--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,0 +1,241 @@
+# Logging in pcp-broker
+
+We use the puppetlabs/structured-logging to log certain events as they
+are handled by the broker.
+
+## Types of messages
+
+In order to allow you to more readily search through your structured
+logs we add a :type field to each log entry that we generate.  These
+types are as follows:
+
+
+### `broker-init`
+
+The broker is being initalised
+
+
+### `broker-start`
+
+The broker is being started
+
+
+### `broker-started`
+
+The broker has been started
+
+
+### `broker-unhandled-message`
+
+The broker recieved a message targetted at it that it cannot handle.
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+* `messagetype` String - The message_type of the message
+
+
+### `broker-state-transition-unknown`
+
+The broker couldn't find a handler function for the named state.
+
+* `state` String - the state
+
+
+### `broker-stop`
+
+The broker is stopping
+
+
+### `broker-stopped`
+
+The broker has been stopped
+
+
+### `connection-open`
+
+A client has connected to the broker.
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+
+
+### `connection-message`
+
+Received a message from a client
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+
+
+### `connection-already-associated`
+
+A client that is associated attempted to associate again.
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+* `uri` String - PCP uri of the new association
+* `existinguri` String - PCP uri of the existing association
+
+
+### `connection-association-failed`
+
+A client failed to become associated with the broker
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+* `uri` String - PCP uri of the association
+
+
+### `connection-message-before-association`
+
+A client sent a message before it was associated with the broker
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+
+
+### `connection-error`
+
+A websocket session error on a connection.
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+
+
+### `connection-close`
+
+A client has disconnected from the broker.
+
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+* `statuscode` Numeric - the websockets status code
+* `reason`  String - the reason given for disconnection
+
+
+### `message-authorization`
+
+A message has been checked if it can be relayed by the broker.
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+* `allowed` Boolean - was the message allowed
+* `message` String - why the message was allowed/denied
+
+
+### `message-expired`
+
+A message has hit its expiry (discovered when sending).
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+
+
+### `message-expired-from-server`
+
+A message that hit its expiry was sourced from the server.
+
+
+### `message-delivery-failure`
+
+A message delivery failed.   This may not be fatal, the message may be retried later.
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+* `reason` String - description of why the delivery failed
+
+
+### `message-redelivery`
+
+A message has been scheduled for redelivery.
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+* `delay` Number - how far in the future will we retry delivery
+
+
+### `message-delivery`
+
+A message is being delivered to a client.
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+* [`commonname`](#commonname)
+* [`remoteaddress`](#remoteaddress)
+
+### `message-deliver-error`
+
+An exception was raised during message delivery.
+
+
+### `queue-enqueue`
+
+A message is being spooled to an internal queue
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+* `queue`  String - name of the queue
+
+
+### `queue-dequeue`
+
+A message is being consumed from an internal queue
+
+* [`messageid`](#messageid)
+* [`sender`](#sender)
+* [`destination`](#destination)
+* `queue`  String - name of the queue
+
+
+### `queue-dequeue-error`
+
+A failure happened in consuming/processing a message from an internal queue
+
+* `queue`  String - name of the queue
+
+
+# Common data
+
+The pcp-broker manages connections and messages, and so log data will
+often include there common properties about these primitives.
+
+## Connections
+
+When reporting about connections we provide the following pieces of
+information:
+
+### `commonname`
+
+The Common Name from the x509 Client certificate
+
+### `remoteaddress`
+
+The host:port of the remote end of the connection
+
+## Messages
+
+When reporting about messages we provide the following pieces of
+information:
+
+### `messageid`
+
+The string uuid of a message
+
+### `source`
+
+The sender of the message as a PCP Uri
+
+### `destination`
+
+An array or single PCP Uri

--- a/project.clj
+++ b/project.clj
@@ -15,8 +15,16 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.3.1"]
 
-                 ;; Transitive dependency for puppetlabs/trapperkeeper-metrics and org.slf4j/jcl-over-slf4
-                 [org.slf4j/slf4j-api "1.7.10"]
+                 ;; Transitive dependency for:
+                 ;;   puppetlabs/trapperkeeper-metrics
+                 ;;   puppetlabs/structured-logging
+                 ;;   org.slf4j/jcl-over-slf4
+                 [org.slf4j/slf4j-api "1.7.12"]
+
+                 ;; Transitive dependency for:
+                 ;;   ch.qos.logback/logback-classic via puppetlabs/trapperkeeper
+                 ;;   net.logstash.logback/logstash-logback-encoder via puppetlabs/structured-logging
+                 [ch.qos.logback/logback-core "1.1.2"]
 
                  ;; Transitive dependency for puppetlabs/trapperkeeper-authorization, and a direct dependency
                  [clj-time "0.10.0"]
@@ -29,6 +37,9 @@
                  [puppetlabs/trapperkeeper-authorization "0.1.5"]
                  [puppetlabs/trapperkeeper-metrics "0.1.1"]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.0"]
+
+                 ;; Exclude clojure dep for now as that will force a ripple up to clojure 1.7.0
+                 [puppetlabs/structured-logging "0.1.0" :exclusions [org.clojure/clojure]]
 
                  [cheshire "5.5.0"]
                  [prismatic/schema "0.4.3"]

--- a/src/puppetlabs/pcp/broker/capsule.clj
+++ b/src/puppetlabs/pcp/broker/capsule.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.pcp.broker.capsule
   (:require [clj-time.coerce :as time-coerce]
             [clj-time.core :as time]
-            [clojure.tools.logging :as log]
             [puppetlabs.pcp.message :as message :refer [Message]]
             [puppetlabs.pcp.protocol :as p]
             [puppetlabs.kitchensink.core :as ks]
@@ -19,6 +18,19 @@
    :message                 Message
    :hops                    (:hops p/DebugChunk)
    (s/optional-key :target) p/Uri})
+
+(def CapsuleLog
+  "Schema for a loggable summary of a capsule"
+  {:messageid p/MessageId
+   :source p/Uri
+   :destination (s/either p/Uri [p/Uri])})
+
+(s/defn ^:always-validate summarize :- CapsuleLog
+  [capsule :- Capsule]
+  {:messageid (get-in capsule [:message :id])
+   :source (get-in capsule [:message :sender])
+   :destination (or (:target capsule)
+                    (get-in capsule [:message :targets]))})
 
 (s/defn ^:always-validate add-hop :- Capsule
   "Adds a debug hop to the message state"

--- a/src/puppetlabs/pcp/broker/connection.clj
+++ b/src/puppetlabs/pcp/broker/connection.clj
@@ -1,0 +1,49 @@
+(ns puppetlabs.pcp.broker.connection
+  (:require [puppetlabs.experimental.websockets.client :as websockets-client]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.pcp.protocol :as p]
+            [schema.core :as s]
+            [slingshot.slingshot :refer [throw+ try+]]))
+
+(def Websocket
+  "Schema for a websocket session"
+  Object)
+
+(def ConnectionState
+  "The states it is possible for a Connection to be in"
+  (s/enum :open :associated))
+
+(def Connection
+  "The state of a connection as managed by the broker in the connections map"
+  {:state ConnectionState
+   :websocket Websocket
+   :remote-address s/Str
+   (s/optional-key :uri) p/Uri
+   :created-at p/ISO8601})
+
+(def ConnectionLog
+  "summarize a connection for logging"
+  {:commonname s/Str
+   :remoteaddress s/Str})
+
+(s/defn ^:always-validate make-connection :- Connection
+  "Return the initial state for a websocket"
+  [ws :- Websocket]
+  {:state :open
+   :websocket ws
+   :remote-address (try+ (.. ws (getSession) (getRemoteAddress) (toString))
+                         (catch Object _
+                           "[UNKNOWN ADDRESS]"))
+   :created-at (ks/timestamp)})
+
+(s/defn ^:always-validate get-cn :- s/Str
+  "Get the client certificate name from a websocket"
+  [connection :- Connection]
+  (let [{:keys [websocket]} connection]
+    (when-let [cert (first (websockets-client/peer-certs websocket))]
+      (ks/cn-for-cert cert))))
+
+(s/defn ^:always-validate summarize :- ConnectionLog
+  [connection :- Connection]
+  {:commonname (get-cn connection)
+   :remoteaddress (:remote-address connection)})

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.pcp.broker.service
-  (:require [clojure.tools.logging :as log]
-            [puppetlabs.pcp.broker.core :as core]
+  (:require [puppetlabs.pcp.broker.core :as core]
             [puppetlabs.pcp.broker.in-memory-inventory :refer [make-inventory record-client find-clients]]
+            [puppetlabs.structured-logging.core :as sl]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
@@ -11,7 +11,7 @@
    [:WebroutingService add-ring-handler add-websocket-handler get-server]
    [:MetricsService get-metrics-registry]]
   (init [this context]
-    (log/info "Initializing broker service")
+    (sl/maplog :info {:type :broker-init} "Initializing broker service")
     (let [activemq-spool     (get-in-config [:pcp-broker :broker-spool])
           accept-consumers   (get-in-config [:pcp-broker :accept-consumers] 4)
           delivery-consumers (get-in-config [:pcp-broker :delivery-consumers] 16)
@@ -31,12 +31,14 @@
                                          :ssl-cert ssl-cert})]
       (assoc context :broker broker)))
   (start [this context]
-    (log/info "Starting broker service")
+    (sl/maplog :info {:type :broker-start} "Starting broker service")
     (let [broker (:broker (service-context this))]
       (core/start broker))
+    (sl/maplog :debug {:type :broker-started} "Broker service started")
     context)
   (stop [this context]
-    (log/info "Shutting down broker service")
+    (sl/maplog :info {:type :broker-stop} "Shutting down broker service")
     (let [broker (:broker (service-context this))]
       (core/stop broker))
+    (sl/maplog :debug {:type :broker-stopped} "Broker service stopped")
     context))

--- a/test-resources/logback-dev.xml
+++ b/test-resources/logback-dev.xml
@@ -7,6 +7,7 @@
 
     <logger name="org.eclipse.jetty.server" level="warn"/>
     <logger name="org.eclipse.jetty.util.log" level="warn"/>
+    <logger name="puppetlabs.pcp.broker" level="trace"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />

--- a/test/puppetlabs/pcp/broker/connection_test.clj
+++ b/test/puppetlabs/pcp/broker/connection_test.clj
@@ -1,0 +1,10 @@
+(ns puppetlabs.pcp.broker.connection-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.pcp.broker.connection :refer :all]))
+
+(deftest make-connection-test
+  (testing "It returns a map that matches represents a new socket"
+    (let [socket (make-connection "ws")]
+      (is (= :open (:state socket)))
+      (is (= "ws" (:websocket socket)))
+      (is (= nil (:endpoint socket))))))


### PR DESCRIPTION
Here we restructure a little and introduce puppetlabs/structured-logging
throughout the code.

All log statements (outside of puppetlabs.puppetdb.mq) become
sl/maplog calls, with a :type field and data relevant to the message
being logged.  Consult doc/logging.md for explanations of the types
and the other logged data.

Connection type and its helpers are moved into its own
`puppetlabs.pcp.broker.connection` namespace.

`Capsule`s and `Connection`s gain a summarize helper to expose the
inspectable/loggable parts, using the pattern of `(foo/summarize :- FooLog [foo :- Foo])`,
so we can verify the structure of our structured logging.

Set the development logfile to log puppetlabs.pcp.broker at TRACE, which after
other changes is still fairly quiet.