### PR TITLE
PCP-124 Close the connection when no peer certificate

### DIFF
--- a/doc/logging.md
+++ b/doc/logging.md
@@ -89,6 +89,13 @@ A client failed to become associated with the broker
 * `uri` String - PCP uri of the association
 
 
+### `connection-no-peer-certificate`
+
+A client didn't provide a x509 peer certifcate when connecting.
+
+* [`remoteaddress`](#remoteaddress)
+
+
 ### `connection-message-before-association`
 
 A client sent a message before it was associated with the broker

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -65,6 +65,18 @@
                                          :open (fn [ws] (deliver connected true)))]
         (is (= true (deref connected (* 2 1000) false)) "Connected within 2 seconds")))))
 
+(deftest it-expects-ssl-client-auth-test
+  (with-app-with-config
+    app
+    [authorization-service broker-service jetty9-service webrouting-service metrics-service]
+    broker-config
+    (let [closed (promise)]
+      (with-open [client (http/create-client)
+                  ws (http/websocket client
+                                     "wss://127.0.0.1:8143/pcp"
+                                     :close (fn [ws code reason] (deliver closed [code reason])))]
+        (is (= [4003 "No client certificate"] (deref closed (* 2 1000) false)) "Disconnected due to no client certificate")))))
+
 (deftest certificate-must-match-test
   (with-app-with-config
     app


### PR DESCRIPTION
Here we protect the broker from weirdness by just disconnecting any connection
that doesn't have a peer certificate, in the on-connect handler.