### PR TITLE
PCP-132 inventory queries should only report on connected clients

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -315,7 +315,7 @@
   (let [message (:message capsule)
         data (message/get-json-data message)]
     (s/validate p/InventoryRequest data)
-    (let [uris ((:find-clients broker) (:query data))
+    (let [uris (filter (partial get-websocket broker) ((:find-clients broker) (:query data)))
           response-data {:uris uris}
           response (-> (message/make-message)
                        (assoc :message_type "http://puppetlabs.com/inventory_response"

--- a/test/puppetlabs/pcp/broker/service_test.clj
+++ b/test/puppetlabs/pcp/broker/service_test.clj
@@ -157,7 +157,7 @@
           (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
           (is (= {:uris ["pcp://client01.example.com/test"]} (message/get-json-data response))))))))
 
-(deftest inventory-node-can-find-previously-connected-node-test
+(deftest inventory-node-cannot-find-previously-connected-node-test
   (with-app-with-config
     app
     [authorization-service broker-service jetty9-service webrouting-service metrics-service]
@@ -173,7 +173,7 @@
         (client/send! client request))
       (let [response (client/recv! client)]
         (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
-        (is (= {:uris ["pcp://client02.example.com/test"]} (message/get-json-data response)))))))
+        (is (= {:uris []} (message/get-json-data response)))))))
 
 ;; Message sending
 (deftest send-to-self-explicit-test


### PR DESCRIPTION
Here we change the behaviour of inventory queries to only report on identites
that are currently connected to the broker.  This is a behavioural change, but
it's more in line with peoples expectations of this API.