### PR TITLE
(maint) Fix capsule/summarize invocation

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -147,7 +147,7 @@
 (s/defn ^:always-validate process-expired-message :- Capsule
   "Reply with a ttl_expired message to the original message sender"
   [broker :- Broker capsule :- Capsule]
-  (sl/maplog :trace (assoc (capsule/summarize)
+  (sl/maplog :trace (assoc (capsule/summarize capsule)
                            :type :message-expired)
              "Message {messageid} for {destination} has expired. Sending a ttl_expired.")
   (let [message (:message capsule)


### PR DESCRIPTION
Here we add a missing argument to the call to capsule/summarize in the
process-expired-message function.