### PR TITLE
PCP-147 improve broker unit test

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -380,7 +380,6 @@
                                         :type :connection-open)
                           "client {commonname} connected from {remoteaddress}"))))))
 
-
 (s/defn ^:always-validate connection-open :- Connection
   [broker :- Broker capsule :- Capsule connection :- Connection]
   (let [message (:message capsule)]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -219,24 +219,23 @@
 (s/defn ^:always-validate deliver-message
   "Message consumer. Delivers a message to the websocket indicated by the :target field"
   [broker :- Broker capsule :- Capsule]
-  (let [message (:message capsule)]
-    (if-let [websocket (get-websocket broker (:target capsule))]
-      (try
-        (let [connection (get-connection broker websocket)]
-          (sl/maplog :debug (merge (capsule/summarize capsule)
-                                   (connection/summarize connection)
-                                   {:type :message-delivery})
-                     "Delivering {messageid} for {destination} to {commonname} at {remoteaddress}")
-          (locking websocket
-            (time! (:on-send (:metrics broker))
-                   (let [capsule (capsule/add-hop capsule (broker-uri broker) "deliver")]
-                     (websockets-client/send! websocket (capsule/encode capsule))))))
-        (catch Exception e
-          (sl/maplog :error e
-                     {:type :message-delivery-error}
-                     "Error in deliver-message")
-          (handle-delivery-failure broker capsule (str e))))
-      (handle-delivery-failure broker capsule "not connected"))))
+  (if-let [websocket (get-websocket broker (:target capsule))]
+    (try
+      (let [connection (get-connection broker websocket)]
+        (sl/maplog :debug (merge (capsule/summarize capsule)
+                                 (connection/summarize connection)
+                                 {:type :message-delivery})
+                   "Delivering {messageid} for {destination} to {commonname} at {remoteaddress}")
+        (locking websocket
+          (time! (:on-send (:metrics broker))
+                 (let [capsule (capsule/add-hop capsule (broker-uri broker) "deliver")]
+                   (websockets-client/send! websocket (capsule/encode capsule))))))
+      (catch Exception e
+        (sl/maplog :error e
+                   {:type :message-delivery-error}
+                   "Error in deliver-message")
+        (handle-delivery-failure broker capsule (str e))))
+    (handle-delivery-failure broker capsule "not connected")))
 
 (s/defn ^:always-validate expand-destinations
   "Message consumer.  Takes a message from the accept queue, expands

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -288,6 +288,18 @@
       (process-inventory-message broker capsule connection)
       (is (= [] (:uris (message/get-json-data (:message @accepted))))))))
 
+(deftest process-server-message-test
+  (let [broker (make-test-broker)
+        message (message/make-message :message_type "http://puppetlabs.com/associate_request")
+        capsule (capsule/wrap message)
+        connection (connection/make-connection "ws1")
+        associate-request (atom nil)]
+    (with-redefs [puppetlabs.pcp.broker.core/process-associate-message (fn [broker capsule connection]
+                                                                         (reset! associate-request capsule)
+                                                                         connection)]
+      (process-server-message broker capsule connection)
+      (is (not= nil @associate-request)))))
+
 (deftest validate-certname-test
   (testing "simple match, no exception"
     (is (validate-certname "pcp://lolcathost/agent" "lolcathost")))

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -277,6 +277,17 @@
             (is (= :associated (:state connection)))
             (is (= ["ws" 4002 "association unsuccessful"] @@closed))))))))
 
+(deftest process-inventory-message-test
+  (let [broker (make-test-broker)
+        message (-> (message/make-message :sender "pcp://test.example.com/test")
+                    (message/set-json-data  {:query ["pcp://*/*"]}))
+        capsule (capsule/wrap message)
+        connection (connection/make-connection "ws1")
+        accepted (atom nil)]
+    (with-redefs [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule] (reset! accepted capsule))]
+      (process-inventory-message broker capsule connection)
+      (is (= [] (:uris (message/get-json-data (:message @accepted))))))))
+
 (deftest validate-certname-test
   (testing "simple match, no exception"
     (is (validate-certname "pcp://lolcathost/agent" "lolcathost")))

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -325,6 +325,17 @@
       (connection-open broker capsule connection)
       (is (not= nil @associate-request)))))
 
+(deftest connection-associated-test
+  (let [broker (make-test-broker)
+        message (message/make-message :message_type "http://puppetlabs.com/associate_request")
+        capsule (capsule/wrap message)
+        connection (connection/make-connection "ws1")
+        accepted (atom nil)]
+    (with-redefs [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule]
+                                                                           (reset! accepted capsule))]
+      (connection-associated broker capsule connection)
+      (is (not= nil @accepted)))))
+
 (deftest determine-next-state-test
   (testing "illegal next states raise due to schema validation"
     (let [broker (make-test-broker)

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -64,8 +64,8 @@
     (is (= 1 (retry-delay (capsule/wrap (message/set-expiry (message/make-message) 1 :seconds))))))
 
   (testing "it's about half the time we have left"
-    (is (= 1 (retry-delay (capsule/wrap (message/set-expiry (message/make-message) 2 :seconds)))))
-    (is (= 4 (retry-delay (capsule/wrap (message/set-expiry (message/make-message) 9 :seconds))))))
+    (is (<= 1 (retry-delay (capsule/wrap (message/set-expiry (message/make-message) 2 :seconds))) 2))
+    (is (<= 4 (retry-delay (capsule/wrap (message/set-expiry (message/make-message) 9 :seconds))) 5)))
 
   (testing "high bounds should be 15 seconds"
     (is (= 15 (retry-delay (capsule/wrap (message/set-expiry (message/make-message) 3000000 :seconds)))))))

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -312,6 +312,19 @@
                    :message "Certificate mismatch.  Sender: 'lolcathost' CN: 'lol.athost'"]
                   (validate-certname "pcp://lolcathost/agent" "lol.athost")))))
 
+(deftest connection-open-test
+  (let [broker (make-test-broker)
+        message (message/make-message :targets ["pcp:///server"]
+                                      :message_type "http://puppetlabs.com/associate_request")
+        capsule (capsule/wrap message)
+        connection (connection/make-connection "ws1")
+        associate-request (atom nil)]
+    (with-redefs [puppetlabs.pcp.broker.core/process-associate-message (fn [broker capsule connection]
+                                                                         (reset! associate-request capsule)
+                                                                         connection)]
+      (connection-open broker capsule connection)
+      (is (not= nil @associate-request)))))
+
 (deftest determine-next-state-test
   (testing "illegal next states raise due to schema validation"
     (let [broker (make-test-broker)

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -108,6 +108,17 @@
         (maybe-send-destination-report broker message-requesting ["pcp://example01.example.com/example"])
         (is ["pcp://example01.example.com/example"] (:targets (message/get-json-data (:message @accepted))))))))
 
+(deftest deliver-message-test
+  (let [broker (make-test-broker)
+        message (message/make-message)
+        capsule (assoc (capsule/wrap message) :target "pcp://example01.example.com/foo")
+        failure (atom nil)]
+    (with-redefs [puppetlabs.pcp.broker.core/handle-delivery-failure (fn [broker capsule message]
+                                                                       (reset! failure {:capsule capsule
+                                                                                        :message message}))]
+      (deliver-message broker capsule)
+      (is (= "not connected" (:message @failure))))))
+
 (deftest make-ring-request-test
   (let [broker (make-test-broker)]
     (testing "it should return a ring request - one target"


### PR DESCRIPTION
Here we add some very basic unit tests to important functions in the core broker namespace.  This bumps our basic coverage up by ~11% by form, ~18% by line and gives us some tests to develop further.

master:
```
Forms covered: 34.09 %
Lines covered: 44.35 %
```

with this PR:
```
Forms covered: 45.47 %
Lines covered: 62.15 %
```