### PR TITLE
PCP-193 move metrics to trapperkeeper-status

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -73,7 +73,6 @@ web-router-service: {
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
     "puppetlabs.pcp.broker.service/broker-service": {
        websocket: "/pcp"
-       metrics: "/"
     }
 }
 ```

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -7,7 +7,7 @@ files needed to set up a pcp-broker listening on `wss://0.0.0.0:8142/pcp`
 
 In order to use the pcp-broker you will need to bootstrap a number of
 dependant trapperkeeper services - a Webserver service, a Webrouting
-service, and a Metrics service.
+service, a Status service, and a Metrics service.
 
 ```
 # bootstrap.cfg
@@ -16,6 +16,7 @@ puppetlabs.trapperkeeper.services.authorization.authorization-service/authorizat
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
+puppetlabs.trapperkeeper.services.status.status-service/status-service
 ```
 
 ## Service configuration
@@ -63,12 +64,13 @@ webserver: {
 }
 ```
 
-The broker will need to be mounted at a path using a
+The broker and the status services will need to be mounted using a
 [webrouting](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/webrouting-config.md)
 configuration.
 
 ```
 web-router-service: {
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
     "puppetlabs.pcp.broker.service/broker-service": {
        websocket: "/pcp"
        metrics: "/"

--- a/project.clj
+++ b/project.clj
@@ -32,11 +32,17 @@
                  ;; Transitive dependency for puppetlabs/trapperkeeper and puppetlabs/trapperkeeper-authorization
                  [puppetlabs/typesafe-config "0.1.4"]
 
+                 ;; Transitive dependency for:
+                 ;;   puppetlabs/trapperkeeper
+                 ;;   compojure via puppetlabs/comidi via puppetlabs/trapperkeeper-status
+                 [org.clojure/tools.macro "0.1.5"]
+
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-authorization "0.1.5"]
                  [puppetlabs/trapperkeeper-metrics "0.1.1"]
                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.0"]
+                 [puppetlabs/trapperkeeper-status "0.2.1"]
 
                  ;; Exclude clojure dep for now as that will force a ripple up to clojure 1.7.0
                  [puppetlabs/structured-logging "0.1.0" :exclusions [org.clojure/clojure]]

--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -1,4 +1,8 @@
 web-router-service: {
+  "puppetlabs.trapperkeeper.services.status.status-service/status-service": {
+    route: "/status"
+    server: "pcp-broker"
+  }
   "puppetlabs.pcp.broker.service/broker-service": {
     websocket: {
       route: "/pcp"

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -44,13 +44,6 @@
    :transitions        {ConnectionState IFn}
    :broker-cn          s/Str})
 
-;; Metrics
-(s/defn metrics-app
-  [broker :- Broker request]
-  {:status 200
-   :headers {"Content-Type" "application/json"}
-   :body (metrics/render-metrics (:metrics-registry broker))})
-
 (s/defn ^:always-validate build-and-register-metrics :- {s/Keyword Object}
   [broker :- Broker]
   (let [registry (:metrics-registry broker)]
@@ -490,7 +483,6 @@
   {:activemq-spool s/Str
    :accept-consumers s/Num
    :delivery-consumers s/Num
-   :add-ring-handler IFn
    :add-websocket-handler IFn
    :record-client IFn
    :find-clients IFn
@@ -501,7 +493,7 @@
 (s/defn ^:always-validate init :- Broker
   [options :- InitOptions]
   (let [{:keys [path activemq-spool accept-consumers delivery-consumers
-                add-ring-handler add-websocket-handler
+                add-websocket-handler
                 record-client find-clients authorization-check
                 get-metrics-registry ssl-cert]} options]
     (let [activemq-broker    (mq/build-embedded-broker activemq-spool)
@@ -521,7 +513,6 @@
                               :broker-cn          (get-broker-cn ssl-cert)}
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
-      (add-ring-handler (partial metrics-app broker) {:route-id :metrics})
       (add-websocket-handler (build-websocket-handlers broker) {:route-id :websocket})
       broker)))
 

--- a/src/puppetlabs/pcp/broker/metrics.clj
+++ b/src/puppetlabs/pcp/broker/metrics.clj
@@ -2,8 +2,7 @@
   (:require [clojure.java.jmx :as jmx]
             [metrics.counters :as counters]
             [metrics.meters :as meters]
-            [metrics.timers :as timers]
-            [cheshire.core :as cheshire]))
+            [metrics.timers :as timers]))
 
 (defn get-pcp-metrics
   "Returns pcp specific metrics as a map"
@@ -27,12 +26,3 @@
   "Returns thread related metrics as a map"
   []
   (apply dissoc (jmx/mbean "java.lang:type=Threading") [:ObjectName :AllThreadIds]))
-
-; TODO(ploubser): Flesh this out
-(defn render-metrics
-  "Returns some clean jmx metrics as a json string"
-  [registry]
-  (cheshire/generate-string (-> (assoc {} :memory (get-memory-metrics))
-                                (assoc :threads (get-thread-metrics))
-                                (assoc :pcp-broker (get-pcp-metrics registry)))
-                            {:pretty true}))

--- a/src/puppetlabs/pcp/broker/metrics.clj
+++ b/src/puppetlabs/pcp/broker/metrics.clj
@@ -5,7 +5,7 @@
             [metrics.timers :as timers]
             [cheshire.core :as cheshire]))
 
-(defn- get-pcp-metrics
+(defn get-pcp-metrics
   "Returns pcp specific metrics as a map"
   [registry]
   (reduce into {}
@@ -18,12 +18,12 @@
                                 :largest (timers/largest v)
                                 :smallest (timers/smallest v)}}) (.getTimers registry))]))
 
-(defn- get-memory-metrics
+(defn get-memory-metrics
   "Returns memory related metrics as a map"
   []
   (dissoc (jmx/mbean "java.lang:type=Memory") :ObjectName))
 
-(defn- get-thread-metrics
+(defn get-thread-metrics
   "Returns thread related metrics as a map"
   []
   (apply dissoc (jmx/mbean "java.lang:type=Threading") [:ObjectName :AllThreadIds]))

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -3,13 +3,15 @@
             [puppetlabs.pcp.broker.in-memory-inventory :refer [make-inventory record-client find-clients]]
             [puppetlabs.structured-logging.core :as sl]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
-            [puppetlabs.trapperkeeper.services :refer [service-context]]))
+            [puppetlabs.trapperkeeper.services :refer [service-context]]
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
 
 (trapperkeeper/defservice broker-service
   [[:AuthorizationService authorization-check]
    [:ConfigService get-in-config]
    [:WebroutingService add-ring-handler add-websocket-handler get-server]
-   [:MetricsService get-metrics-registry]]
+   [:MetricsService get-metrics-registry]
+   [:StatusService register-status]]
   (init [this context]
     (sl/maplog :info {:type :broker-init} "Initializing broker service")
     (let [activemq-spool     (get-in-config [:pcp-broker :broker-spool])
@@ -29,6 +31,10 @@
                                          :authorization-check authorization-check
                                          :get-metrics-registry get-metrics-registry
                                          :ssl-cert ssl-cert})]
+      (register-status "broker-service"
+                       (status-core/get-artifact-version "puppetlabs" "pcp-broker")
+                       1
+                       (partial core/status broker))
       (assoc context :broker broker)))
   (start [this context]
     (sl/maplog :info {:type :broker-start} "Starting broker service")

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -9,7 +9,7 @@
 (trapperkeeper/defservice broker-service
   [[:AuthorizationService authorization-check]
    [:ConfigService get-in-config]
-   [:WebroutingService add-ring-handler add-websocket-handler get-server]
+   [:WebroutingService add-websocket-handler get-server]
    [:MetricsService get-metrics-registry]
    [:StatusService register-status]]
   (init [this context]
@@ -24,7 +24,6 @@
           broker             (core/init {:activemq-spool activemq-spool
                                          :accept-consumers accept-consumers
                                          :delivery-consumers delivery-consumers
-                                         :add-ring-handler (partial add-ring-handler this)
                                          :add-websocket-handler (partial add-websocket-handler this)
                                          :record-client  (partial record-client inventory)
                                          :find-clients   (partial find-clients inventory)

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -4,3 +4,4 @@ puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-servi
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
+puppetlabs.trapperkeeper.services.status.status-service/status-service

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -37,8 +37,7 @@
                :ssl-crl-path "./test-resources/ssl/ca/ca_crl.pem"}
 
    :web-router-service
-   {:puppetlabs.pcp.broker.service/broker-service {:websocket "/pcp"
-                                                   :metrics "/"}
+   {:puppetlabs.pcp.broker.service/broker-service {:websocket "/pcp"}
     :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"}
 
    :metrics {:enabled true}


### PR DESCRIPTION
With this set of changes we move from having a home-grown ring app called `metrics` mounted by convention at "/" to using trapperkeeper-status.  

As a convenience the test configuration mounts the trapperkeeper-status application at the more conventional "/status" path so statistics may now be queried with `curl -k  'https://localhost:8142/status/v1/services/broker-service?level=debug'`