### PR TITLE
PCP-199 Rename `websocket` route-id

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -72,7 +72,7 @@ configuration.
 web-router-service: {
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
     "puppetlabs.pcp.broker.service/broker-service": {
-       websocket: "/pcp"
+       v1: "/pcp"
     }
 }
 ```

--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -4,7 +4,7 @@ web-router-service: {
     server: "pcp-broker"
   }
   "puppetlabs.pcp.broker.service/broker-service": {
-    websocket: {
+    v1: {
       route: "/pcp"
       server: "pcp-broker"
     }

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -513,7 +513,7 @@
                               :broker-cn          (get-broker-cn ssl-cert)}
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
-      (add-websocket-handler (build-websocket-handlers broker) {:route-id :websocket})
+      (add-websocket-handler (build-websocket-handlers broker) {:route-id :v1})
       broker)))
 
 (s/defn ^:always-validate start

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -18,7 +18,7 @@
           accept-consumers   (get-in-config [:pcp-broker :accept-consumers] 4)
           delivery-consumers (get-in-config [:pcp-broker :delivery-consumers] 16)
           inventory          (make-inventory)
-          ssl-cert           (if-let [server (get-server this :websocket)]
+          ssl-cert           (if-let [server (get-server this :v1)]
                                (get-in-config [:webserver (keyword server) :ssl-cert])
                                (get-in-config [:webserver :ssl-cert]))
           broker             (core/init {:activemq-spool activemq-spool

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -37,7 +37,7 @@
                :ssl-crl-path "./test-resources/ssl/ca/ca_crl.pem"}
 
    :web-router-service
-   {:puppetlabs.pcp.broker.service/broker-service {:websocket "/pcp"}
+   {:puppetlabs.pcp.broker.service/broker-service {:v1 "/pcp"}
     :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"}
 
    :metrics {:enabled true}


### PR DESCRIPTION
Here we rename the existing `websocket` route-id to `v1` to more clearly
associate the mounted handler with the version of the PCP protocol it
supports.

It is expected the v2 handler, when created, will have a default mountpoint of
`/pcp/v2` like so:

    web-router-service: {
      "puppetlabs.pcp.broker.service/broker-service": {
        v1: "/pcp"
        v2: "/pcp/v2"
      }
    }