### PR TITLE
(maint) cleanup released web-routes.conf

### DIFF
--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -8,9 +8,5 @@ web-router-service: {
       route: "/pcp"
       server: "pcp-broker"
     }
-    metrics: {
-      route: "/"
-      server: "pcp-broker"
-    }
   }
 }


### PR DESCRIPTION
PCP-193 (merged as 28e5329) removed the metrics endpoint from the broker.  Here
we tidy up the web-routes configuration.