### PR TITLE
(PCP-222) Correct the ordering of the default rule

### DIFF
--- a/resources/ext/config/conf.d/authorization.conf
+++ b/resources/ext/config/conf.d/authorization.conf
@@ -9,7 +9,7 @@ authorization: {
          path: "/pcp-broker/send"
       }
       allow-unauthenticated: true
-      sort-order: 1
+      sort-order: 400
     },
   ]
 }


### PR DESCRIPTION
As this rule comes from a package it should have a sort order in
the range 400-600 so that users can override with rules earlier and augment
with rules later.