### PR TITLE
(maint) explain more about the loglevels in use

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -3,5 +3,6 @@
 Suggested order of reading:
 
 * [Configuration](configuration.md)
+* [Logging](logging.md)
 * [Authentication](authentication.md)
 * [Authorization](authorization.md)

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -3,6 +3,17 @@
 We use the puppetlabs/structured-logging to log certain events as they
 are handled by the broker.
 
+## Levels and their uses
+
+The default logging level (INFO) for the broker should be fairly quiet, this is the
+intended scheme for logging levels:
+
+* ERROR - only really bad things
+* WARN - mostly bad things
+* INFO - service started/stopped
+* DEBUG - client connecting, client session establishment, client disconnected, message acceptance, message delivery
+* TRACE - messages moving through queues, message information during association.
+
 ## Types of messages
 
 In order to allow you to more readily search through your structured
@@ -14,16 +25,19 @@ types are as follows:
 
 The broker is being initalised
 
+Level: INFO
 
 ### `broker-start`
 
 The broker is being started
 
+Level: INFO
 
 ### `broker-started`
 
 The broker has been started
 
+Level: DEBUG
 
 ### `broker-unhandled-message`
 
@@ -33,6 +47,7 @@ The broker recieved a message targetted at it that it cannot handle.
 * [`remoteaddress`](#remoteaddress)
 * `messagetype` String - The message_type of the message
 
+Level: DEBUG
 
 ### `broker-state-transition-unknown`
 
@@ -40,16 +55,19 @@ The broker couldn't find a handler function for the named state.
 
 * `state` String - the state
 
+Level: ERROR
 
 ### `broker-stop`
 
 The broker is stopping
 
+Level: INFO
 
 ### `broker-stopped`
 
 The broker has been stopped
 
+Level: DEBUG
 
 ### `connection-open`
 
@@ -58,6 +76,7 @@ A client has connected to the broker.
 * [`commonname`](#commonname)
 * [`remoteaddress`](#remoteaddress)
 
+Level: DEBUG
 
 ### `connection-message`
 
@@ -69,6 +88,7 @@ Received a message from a client
 * [`sender`](#sender)
 * [`destination`](#destination)
 
+Level: TRACE
 
 ### `connection-already-associated`
 
@@ -79,6 +99,7 @@ A client that is associated attempted to associate again.
 * `uri` String - PCP uri of the new association
 * `existinguri` String - PCP uri of the existing association
 
+Level: WARN
 
 ### `connection-association-failed`
 
@@ -88,6 +109,7 @@ A client failed to become associated with the broker
 * [`remoteaddress`](#remoteaddress)
 * `uri` String - PCP uri of the association
 
+Level: DEBUG
 
 ### `connection-no-peer-certificate`
 
@@ -95,6 +117,7 @@ A client didn't provide a x509 peer certifcate when connecting.
 
 * [`remoteaddress`](#remoteaddress)
 
+Level: DEBUG
 
 ### `connection-message-before-association`
 
@@ -106,6 +129,7 @@ A client sent a message before it was associated with the broker
 * [`sender`](#sender)
 * [`destination`](#destination)
 
+Level: WARN
 
 ### `connection-error`
 
@@ -114,6 +138,7 @@ A websocket session error on a connection.
 * [`commonname`](#commonname)
 * [`remoteaddress`](#remoteaddress)
 
+Level: ERROR
 
 ### `connection-close`
 
@@ -124,6 +149,7 @@ A client has disconnected from the broker.
 * `statuscode` Numeric - the websockets status code
 * `reason`  String - the reason given for disconnection
 
+Level: DEBUG
 
 ### `message-authorization`
 
@@ -135,6 +161,7 @@ A message has been checked if it can be relayed by the broker.
 * `allowed` Boolean - was the message allowed
 * `message` String - why the message was allowed/denied
 
+Level: TRACE
 
 ### `message-expired`
 
@@ -144,11 +171,13 @@ A message has hit its expiry (discovered when sending).
 * [`sender`](#sender)
 * [`destination`](#destination)
 
+Level: TRACE
 
 ### `message-expired-from-server`
 
 A message that hit its expiry was sourced from the server.
 
+Level: TRACE
 
 ### `message-delivery-failure`
 
@@ -159,6 +188,7 @@ A message delivery failed.   This may not be fatal, the message may be retried l
 * [`destination`](#destination)
 * `reason` String - description of why the delivery failed
 
+Level: TRACE
 
 ### `message-redelivery`
 
@@ -169,6 +199,7 @@ A message has been scheduled for redelivery.
 * [`destination`](#destination)
 * `delay` Number - how far in the future will we retry delivery
 
+Level: TRACE
 
 ### `message-delivery`
 
@@ -180,10 +211,13 @@ A message is being delivered to a client.
 * [`commonname`](#commonname)
 * [`remoteaddress`](#remoteaddress)
 
+Level: DEBUG
+
 ### `message-deliver-error`
 
 An exception was raised during message delivery.
 
+Level: ERROR
 
 ### `queue-enqueue`
 
@@ -194,6 +228,7 @@ A message is being spooled to an internal queue
 * [`destination`](#destination)
 * `queue`  String - name of the queue
 
+Level: TRACE
 
 ### `queue-dequeue`
 
@@ -204,6 +239,7 @@ A message is being consumed from an internal queue
 * [`destination`](#destination)
 * `queue`  String - name of the queue
 
+Level: TRACE
 
 ### `queue-dequeue-error`
 
@@ -211,6 +247,7 @@ A failure happened in consuming/processing a message from an internal queue
 
 * `queue`  String - name of the queue
 
+Level: ERROR
 
 # Common data
 


### PR DESCRIPTION
Here we add the logging level rationale from PCP-5 to the doc/logging.md where
it will be the most useful, and also call out which level each message will be
seen at.