### PR TITLE
PCP-195 Supply "in-reply-to" header when responding to a message

### DIFF
--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -10,6 +10,7 @@
 
 (defprotocol WsClient
   (close [_])
+  (sendbytes! [_ bytes])
   (send! [_ message])
   (recv! [_] [_ timeout]
     "Returns nil on timeout, [code reason] on close, message/Message on message"))
@@ -20,6 +21,8 @@
     (async/close! message-channel)
     (.close ws-client)
     (.close http-client))
+  (sendbytes! [_ bytes]
+    (http/send ws-client :byte bytes))
   (send! [_ message]
     (http/send ws-client :byte (message/encode message)))
   (recv! [this] (recv! this (* 10 1000)))
@@ -60,6 +63,7 @@
     (if check-ok
       (let [response (recv! wrapper)]
         (is (= "http://puppetlabs.com/associate_response" (:message_type response)))
+        (is (= (:id association-request) (:in-reply-to response)))
         (is (= {:id (:id association-request)
                 :success true}
                (message/get-json-data response)))))


### PR DESCRIPTION
The "in-reply-to" envelope property was initially added to the
inventory_response codepath in commit 92b66d1c.  Here we change the
behaviour of the broker to supply this property whenever we are
clearly responding to a message, allowing a client to correlate a
response with its original request.