### PR TITLE
PCP-194 Make Capsule and Connection types records

### DIFF
--- a/src/puppetlabs/pcp/broker/activemq.clj
+++ b/src/puppetlabs/pcp/broker/activemq.clj
@@ -1,11 +1,12 @@
 (ns puppetlabs.pcp.broker.activemq
   (:require [clamq.protocol.connection :as mq-conn]
             [clamq.protocol.consumer :as mq-cons]
-            [puppetlabs.pcp.broker.capsule :as capsule :refer [Capsule CapsuleLog]]
+            [puppetlabs.pcp.broker.capsule :as capsule :refer [CapsuleLog]]
             [puppetlabs.puppetdb.mq :as mq]
             [puppetlabs.structured-logging.core :as sl]
             [schema.core :as s]
-            [taoensso.nippy :as nippy]))
+            [taoensso.nippy :as nippy])
+  (:import (puppetlabs.pcp.broker.capsule Capsule)))
 
 ;; This is a bit rude/lazy, reaching right into puppetdb sources we've
 ;; copied into our tree.  If this proves out we should talk to

--- a/src/puppetlabs/pcp/broker/capsule.clj
+++ b/src/puppetlabs/pcp/broker/capsule.clj
@@ -7,17 +7,35 @@
             [schema.core :as s])
   (:import (org.joda.time DateTime)))
 
+(defprotocol CapsuleInterface
+  (summarize [capsule]
+    "Summarize the capsule")
+  (add-hop [capsule server stage]
+    [capsule server stage timestamp]
+    "Add a debugging hop to the capsule")
+  (expired? [capsule]
+    "Has the capsule expired?")
+  (encode [capsule]
+    "Return the bytes to send when sending this message"))
+
 ;; A Capsule is a message as it moves across the broker from queue to
 ;; queue.  Currently it contains an actual Message, but in future it
 ;; might make sense to just contain a message-id with the message
 ;; itself in some other persistent storage.
 
-(def Capsule
-  "Schema for a message moving through the broker"
-  {:expires                 DateTime
-   :message                 Message
-   :hops                    (:hops p/DebugChunk)
-   (s/optional-key :target) p/Uri})
+(declare -summarize -add-hop -expired? -encode)
+
+(s/defrecord Capsule
+             [expires :- DateTime
+              message :- Message
+              hops    :- (:hops p/DebugChunk)
+              target  :- (s/maybe p/Uri)]
+  CapsuleInterface
+  (summarize [capsule] (-summarize capsule))
+  (add-hop [capsule server stage] (-add-hop capsule server stage))
+  (add-hop [capsule server stage timestamp] (-add-hop capsule server stage timestamp))
+  (expired? [capsule] (-expired? capsule))
+  (encode [capsule] (-encode capsule)))
 
 (def CapsuleLog
   "Schema for a loggable summary of a capsule"
@@ -25,31 +43,31 @@
    :source p/Uri
    :destination (s/either p/Uri [p/Uri])})
 
-(s/defn ^:always-validate summarize :- CapsuleLog
+(s/defn ^:always-validate -summarize :- CapsuleLog
   [capsule :- Capsule]
   {:messageid (get-in capsule [:message :id])
    :source (get-in capsule [:message :sender])
    :destination (or (:target capsule)
                     (get-in capsule [:message :targets]))})
 
-(s/defn ^:always-validate add-hop :- Capsule
+(s/defn ^:always-validate -add-hop :- Capsule
   "Adds a debug hop to the message state"
   ([capsule :- Capsule server :- p/Uri stage :- s/Str]
    (add-hop capsule server stage (ks/timestamp)))
-  ([state :- Capsule server :- p/Uri stage :- s/Str timestamp :- p/ISO8601]
+  ([capsule :- Capsule server :- p/Uri stage :- s/Str timestamp :- p/ISO8601]
    (let [hop {:server server
               :time   timestamp
               :stage  stage}]
-     (assoc state :hops (conj (vec (:hops state)) hop)))))
+     (assoc capsule :hops (conj (vec (:hops capsule)) hop)))))
 
-(s/defn ^:always-validate expired? :- s/Bool
+(s/defn ^:always-validate -expired? :- s/Bool
   "Check whether a message has expired or not"
   [message :- Capsule]
   (let [expires (:expires message)
         now     (time/now)]
     (time/after? now expires)))
 
-(s/defn ^:always-validate encode :- message/ByteArray
+(s/defn ^:always-validate -encode :- message/ByteArray
   "Return the bytes we should send when sending this Capsule.  Adds
   the debug chunk to the message"
   [capsule :- Capsule]
@@ -61,6 +79,7 @@
 (s/defn ^:always-validate wrap :- Capsule
   "Wrap a Message producing a Capsule"
   [message :- Message]
-  {:expires  (time-coerce/to-date-time (:expires message))
-   :message  message
-   :hops     []})
+  (map->Capsule
+   {:expires  (time-coerce/to-date-time (:expires message))
+    :message  message
+    :hops     []}))

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -5,8 +5,8 @@
             [metrics.gauges :as gauges]
             [puppetlabs.experimental.websockets.client :as websockets-client]
             [puppetlabs.pcp.broker.activemq :as activemq]
-            [puppetlabs.pcp.broker.capsule :as capsule :refer [Capsule]]
-            [puppetlabs.pcp.broker.connection :as connection :refer [Websocket ConnectionState Connection]]
+            [puppetlabs.pcp.broker.capsule :as capsule]
+            [puppetlabs.pcp.broker.connection :as connection :refer [Websocket ConnectionState]]
             [puppetlabs.pcp.broker.metrics :as metrics]
             [puppetlabs.pcp.message :as message :refer [Message]]
             [puppetlabs.pcp.protocol :as p]
@@ -19,7 +19,9 @@
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [schema.core :as s]
             [slingshot.slingshot :refer [throw+ try+]])
-  (:import (clojure.lang IFn Atom)))
+  (:import (puppetlabs.pcp.broker.capsule Capsule)
+           (puppetlabs.pcp.broker.connection Connection)
+           (clojure.lang IFn Atom)))
 
 (def UriMap
   "Mapping of Uri to Websocket, for sending"

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -6,7 +6,8 @@
             [puppetlabs.pcp.broker.connection :as connection]
             [puppetlabs.pcp.message :as message]
             [schema.core :as s]
-            [slingshot.test]))
+            [slingshot.test])
+  (:import (puppetlabs.pcp.broker.connection Connection)))
 
 (s/defn ^:always-validate make-test-broker :- Broker
   "Return a minimal clean broker state"
@@ -300,7 +301,7 @@
       (process-server-message broker capsule connection)
       (is (not= nil @associate-request)))))
 
-(s/defn ^:always-validate dummy-connection-from :- connection/Connection
+(s/defn ^:always-validate dummy-connection-from :- Connection
   [common-name]
   (assoc (connection/make-connection "ws1")
          :common-name common-name))


### PR DESCRIPTION
The previous implementation of Capsule and Connection are straight clojure maps
with validation using schemas.  Here we swap these maps for records, as this
provides a slighly tighter in-memory representation, and also introduces a more
explicit interface for these types.