### PR TITLE
(maint) Remove naming conflicts with PuppetDB

### DIFF
--- a/src/puppetlabs/pcp/broker/activemq.clj
+++ b/src/puppetlabs/pcp/broker/activemq.clj
@@ -2,7 +2,7 @@
   (:require [clamq.protocol.connection :as mq-conn]
             [clamq.protocol.consumer :as mq-cons]
             [puppetlabs.pcp.broker.capsule :as capsule :refer [CapsuleLog]]
-            [puppetlabs.puppetdb.mq :as mq]
+            [puppetlabs.pcp.broker.borrowed.mq :as mq]
             [puppetlabs.structured-logging.core :as sl]
             [schema.core :as s]
             [taoensso.nippy :as nippy])
@@ -15,7 +15,7 @@
 (s/defn ^:always-validate queue-message
   "Queue a message on a middleware"
   [queue :- s/Str capsule :- Capsule & args]
-  (let [mq-spec "vm://localhost?create=false"
+  (let [mq-spec "vm://pcp?create=false"
         mq-endpoint queue]
     (sl/maplog :trace (assoc (capsule/summarize capsule)
                              :queue queue
@@ -26,7 +26,7 @@
 
 (defn subscribe-to-queue
   [queue callback-fn consumer-count]
-  (let [mq-spec "vm://localhost?create=false"]
+  (let [mq-spec "vm://pcp?create=false"]
     (let [conn (mq/activemq-connection mq-spec)]
       (doall (for [i (range consumer-count)]
                (let [consumer (mq-conn/consumer conn

--- a/src/puppetlabs/pcp/broker/borrowed/cheshire.clj
+++ b/src/puppetlabs/pcp/broker/borrowed/cheshire.clj
@@ -1,4 +1,4 @@
-(ns puppetlabs.puppetdb.cheshire
+(ns puppetlabs.pcp.broker.borrowed.cheshire
   "Cheshire related functions
 
    This front-ends the common set of core cheshire functions:
@@ -9,7 +9,9 @@
    * parse-stream
 
    This namespace when 'required' will also setup some common JSON encoders
-   globally, so you can avoid doing this for each call."
+   globally, so you can avoid doing this for each call.
+
+  Copied from PuppetDB."
   (:require [cheshire.generate :as generate]
             [cheshire.core :as core]
             [clj-time.coerce :as coerce]
@@ -45,16 +47,16 @@
 (def generate-stream core/generate-stream)
 
 (defn generate-pretty-string
-  "Thinly wraps cheshire.core/generate-string, adding the PuppetDB default date format
-   and pretty printing from `default-pretty-opts`"
+  "Thinly wraps cheshire.core/generate-string, adding the default date format
+  and pretty printing from `default-pretty-opts`"
   ([obj]
    (generate-pretty-string obj default-pretty-opts))
   ([obj opts]
    (generate-string obj (merge default-pretty-opts opts))))
 
 (defn generate-pretty-stream
-  "Thinly wraps cheshire.core/generate-stream, adding the PuppetDB default date format
-   and pretty printing from `default-pretty-opts`"
+  "Thinly wraps cheshire.core/generate-stream, adding the default date format
+  and pretty printing from `default-pretty-opts`"
   ([obj writer]
    (generate-pretty-stream obj writer default-pretty-opts))
   ([obj writer opts]

--- a/src/puppetlabs/pcp/broker/borrowed/mq.clj
+++ b/src/puppetlabs/pcp/broker/borrowed/mq.clj
@@ -1,4 +1,5 @@
-(ns puppetlabs.puppetdb.mq
+(ns puppetlabs.pcp.broker.borrowed.mq
+  "Copied from PuppetDB."
   (:import [org.apache.activemq.broker BrokerService]
            [org.apache.activemq ScheduledMessage]
            [org.apache.activemq.usage SystemUsage]
@@ -6,7 +7,7 @@
            [org.apache.activemq ActiveMQConnectionFactory]
            [org.springframework.jms.connection CachingConnectionFactory]
            [org.springframework.jms.listener DefaultMessageListenerContainer])
-  (:require [puppetlabs.puppetdb.cheshire :as json]
+  (:require [puppetlabs.pcp.broker.borrowed.cheshire :as json]
             [clamq.activemq :as activemq]
             [clamq.protocol.connection :as mq-conn]
             [clamq.protocol.consumer :as mq-consumer]
@@ -82,7 +83,7 @@
   ([dir]
    {:pre  [(string? dir)]
     :post [(instance? BrokerService %)]}
-   (build-embedded-broker "localhost" dir))
+   (build-embedded-broker "pcp" dir))
   ([name dir]
    {:pre  [(string? name)
            (string? dir)]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -12,7 +12,7 @@
             [puppetlabs.pcp.protocol :as p]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.metrics :refer [time!]]
-            [puppetlabs.puppetdb.mq :as mq]
+            [puppetlabs.pcp.broker.borrowed.mq :as mq]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.structured-logging.core :as sl]
             [puppetlabs.trapperkeeper.authorization.ring :as ring]


### PR DESCRIPTION
This commit renames the namespaces copied from PuppetDB so that they are
unique to this project. This avoids conflicts with PuppetDB that arise
from having two (now different!) namespaces with the same name.

Similarly, changed the name of the embedded broker from "localhost" to
"pcp" to allow for multiple ActiveMQ instances to be started in the same
process.

These changes are meant to enable pcp-broker to be embedded in the same
jar/process as PuppetDB. Eventually this code probably ought to be
migrated to shared libraries or a dedicated trapperkeeper service (for
ActiveMQ), but for now this avoids conflicts.