### PR TITLE
PCP-250 Add multiple protocol version support

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -64,7 +64,7 @@ webserver: {
 }
 ```
 
-The broker and the status services will need to be mounted using a
+The brokers protocol handlers and the status service will need to be mounted using a
 [webrouting](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/webrouting-config.md)
 configuration.
 
@@ -73,6 +73,7 @@ web-router-service: {
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
     "puppetlabs.pcp.broker.service/broker-service": {
        v1: "/pcp"
+       vNext: "/pcp/vNext"
     }
 }
 ```

--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -8,5 +8,9 @@ web-router-service: {
       route: "/pcp"
       server: "pcp-broker"
     }
+    vNext: {
+      route: "/pcp/vNext"
+      server: "pcp-broker"
+    }
   }
 }

--- a/src/puppetlabs/pcp/broker/capsule.clj
+++ b/src/puppetlabs/pcp/broker/capsule.clj
@@ -67,14 +67,14 @@
         now     (time/now)]
     (time/after? now expires)))
 
-(s/defn ^:always-validate -encode :- message/ByteArray
-  "Return the bytes we should send when sending this Capsule.  Adds
+(s/defn ^:always-validate -encode :- Message
+  "Return the Message we should send when sending this Capsule.  Adds
   the debug chunk to the message"
   [capsule :- Capsule]
   (let [message (:message capsule)
         debug   {:hops (:hops capsule)}]
     (s/validate p/DebugChunk debug)
-    (message/encode (message/set-json-debug message debug))))
+    (message/set-json-debug message debug)))
 
 (s/defn ^:always-validate wrap :- Capsule
   "Wrap a Message producing a Capsule"

--- a/test/unit/puppetlabs/pcp/broker/connection_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/connection_test.clj
@@ -2,9 +2,13 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.pcp.broker.connection :refer :all]))
 
+(def identity-codec
+  {:encode identity
+   :decode identity})
+
 (deftest make-connection-test
   (testing "It returns a map that matches represents a new socket"
-    (let [socket (make-connection "ws")]
+    (let [socket (make-connection "ws" identity-codec)]
       (is (= :open (:state socket)))
       (is (= "ws" (:websocket socket)))
       (is (= nil (:endpoint socket))))))

--- a/test/utils/puppetlabs/pcp/testutils.clj
+++ b/test/utils/puppetlabs/pcp/testutils.clj
@@ -1,0 +1,10 @@
+(ns puppetlabs.pcp.testutils
+  (:require [clojure.test :refer :all]))
+
+(defmacro dotestseq [bindings & body]
+  (if-not (seq bindings)
+    `(do ~@body)
+    (let [case-versions (remove keyword? (take-nth 2 bindings))]
+      `(doseq ~bindings
+         (testing (str "Testing case " '~case-versions)
+           ~@body)))))

--- a/test/utils/puppetlabs/pcp/testutils.clj
+++ b/test/utils/puppetlabs/pcp/testutils.clj
@@ -6,5 +6,10 @@
     `(do ~@body)
     (let [case-versions (remove keyword? (take-nth 2 bindings))]
       `(doseq ~bindings
-         (testing (str "Testing case " '~case-versions)
+         (testing (str "Testing case: " (clojure.string/join
+                                         ", "
+                                         (map #(clojure.string/join ": " %)
+                                              (partition
+                                               2
+                                               (interleave '~case-versions (list ~@case-versions))))))
            ~@body)))))


### PR DESCRIPTION
We dub the developing version of the protocol "vNext" for now, as
it is a developing set of changes to the already established PCP
v1.0, and give it the websockets route :vNext.

Due to the closeness of v1.0 and vNext (vNext currently just adds
the optional in-reply-to header to all reply types), the brokers
internal representation of messages is vNext, which we then transform
when sending/receiving message via a Codec which is a property of
the connection derived from the uri the connection was established
on.