### PR TITLE
PCP-295 Track and return the service status

### DIFF
--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -24,7 +24,8 @@
                 :metrics-registry   metrics.core/default-registry
                 :metrics            {}
                 :transitions        {}
-                :broker-cn          "broker.example.com"}
+                :broker-cn          "broker.example.com"
+                :state              (atom :running)}
         metrics (build-and-register-metrics broker)
         broker (assoc broker :metrics metrics)]
     broker))


### PR DESCRIPTION
Here we make the trapperkeeper-status endpoint more useful by actually tracking
the broker-service state so we can return a usable value to the server status
api.

    $ while true ; do  curl -sk https://127.0.0.1:8142/status/v1/services/broker-service | jq ".state" ; done
    "starting"
    "starting"
    "starting"
    "starting"
    "running"
    "running"