### PR TITLE
PCP-292 Add protocol-next feature switch

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -73,6 +73,7 @@ web-router-service: {
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
     "puppetlabs.pcp.broker.service/broker-service": {
        v1: "/pcp"
+       # vNext endpoint will need to be enabled with pcp-broker.protocol-vnext property
        vNext: "/pcp/vNext"
     }
 }
@@ -92,5 +93,8 @@ pcp-broker: {
 
     ## Number of consumers for the delivery queue.  Default is 16
     # delivery-consumers = 16
+
+    ## Enable the vNext protocol (needs corresponding webroute).  Default is false
+    # protocol-vnext = false
 }
 ```

--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -8,9 +8,5 @@ web-router-service: {
       route: "/pcp"
       server: "pcp-broker"
     }
-    vNext: {
-      route: "/pcp/vNext"
-      server: "pcp-broker"
-    }
   }
 }

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -506,6 +506,7 @@
    :find-clients IFn
    :authorization-check IFn
    :get-metrics-registry IFn
+   :protocol-next s/Bool
    :ssl-cert s/Str})
 
 (s/def default-codec :- Codec
@@ -528,6 +529,7 @@
   (let [{:keys [path activemq-spool accept-consumers delivery-consumers
                 add-websocket-handler
                 record-client find-clients authorization-check
+                protocol-next
                 get-metrics-registry ssl-cert]} options]
     (let [activemq-broker    (mq/build-embedded-broker activemq-spool)
           broker             {:activemq-broker    activemq-broker
@@ -548,7 +550,8 @@
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
       (add-websocket-handler (build-websocket-handlers broker v1-codec) {:route-id :v1})
-      (add-websocket-handler (build-websocket-handlers broker default-codec) {:route-id :vNext})
+      (when protocol-next
+        (add-websocket-handler (build-websocket-handlers broker default-codec) {:route-id :vNext}))
       broker)))
 
 (s/defn ^:always-validate start

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -17,6 +17,7 @@
     (let [activemq-spool     (get-in-config [:pcp-broker :broker-spool])
           accept-consumers   (get-in-config [:pcp-broker :accept-consumers] 4)
           delivery-consumers (get-in-config [:pcp-broker :delivery-consumers] 16)
+          protocol-next      (get-in-config [:pcp-broker :protocol-next] false)
           inventory          (make-inventory)
           ssl-cert           (if-let [server (get-server this :v1)]
                                (get-in-config [:webserver (keyword server) :ssl-cert])
@@ -29,6 +30,7 @@
                                          :find-clients   (partial find-clients inventory)
                                          :authorization-check authorization-check
                                          :get-metrics-registry get-metrics-registry
+                                         :protocol-next protocol-next
                                          :ssl-cert ssl-cert})]
       (register-status "broker-service"
                        (status-core/get-artifact-version "puppetlabs" "pcp-broker")

--- a/test-resources/conf.d/pcp-broker.conf
+++ b/test-resources/conf.d/pcp-broker.conf
@@ -7,4 +7,7 @@ pcp-broker: {
 
     ## Number of consumers for the delivery queue.  Default is 16
     # delivery-consumers = 16
+
+    ## Enable the vNext protocol endpoint (must be mounted with a web-route)
+    protocol-next = true
 }

--- a/test-resources/conf.d/web-routes.conf
+++ b/test-resources/conf.d/web-routes.conf
@@ -1,1 +1,16 @@
-../../resources/ext/config/conf.d/web-routes.conf
+web-router-service: {
+  "puppetlabs.trapperkeeper.services.status.status-service/status-service": {
+    route: "/status"
+    server: "pcp-broker"
+  }
+  "puppetlabs.pcp.broker.service/broker-service": {
+    v1: {
+      route: "/pcp"
+      server: "pcp-broker"
+    }
+    vNext: {
+      route: "/pcp/vNext"
+      server: "pcp-broker"
+    }
+  }
+}

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -46,7 +46,8 @@
 
    :pcp-broker {:broker-spool "test-resources/tmp/spool"
                 :accept-consumers 2
-                :delivery-consumers 2}})
+                :delivery-consumers 2
+                :protocol-next true}})
 
 (def protocol-versions
   "The short names of protocol versions"


### PR DESCRIPTION
Here we add a simple feature switch to enable the next protocol
mountpoint.  This will allow existing users to leave the developing
protocol support disabled until it becomes important enough to make
the configuration of it via webroutes mandatory.

As vNext isn't finalised/public yet, remove it from the default
web-routes.conf that ezbake will publish, and add a more specific
test-resources/conf.d/web-routes.conf.