### PR TITLE
PCP-292 Only mount vNext when a web-route is supplied.

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -68,6 +68,8 @@ The brokers protocol handlers and the status service will need to be mounted usi
 [webrouting](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/webrouting-config.md)
 configuration.
 
+The vNext webroute is optional, and not reccomended for production deployments.
+
 ```
 web-router-service: {
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"

--- a/resources/ext/config/conf.d/web-routes.conf
+++ b/resources/ext/config/conf.d/web-routes.conf
@@ -8,9 +8,5 @@ web-router-service: {
       route: "/pcp"
       server: "pcp-broker"
     }
-    vNext: {
-      route: "/pcp/vNext"
-      server: "pcp-broker"
-    }
   }
 }

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -506,6 +506,7 @@
    :find-clients IFn
    :authorization-check IFn
    :get-metrics-registry IFn
+   :get-route IFn
    :ssl-cert s/Str})
 
 (s/def default-codec :- Codec
@@ -528,6 +529,7 @@
   (let [{:keys [path activemq-spool accept-consumers delivery-consumers
                 add-websocket-handler
                 record-client find-clients authorization-check
+                get-route
                 get-metrics-registry ssl-cert]} options]
     (let [activemq-broker    (mq/build-embedded-broker activemq-spool)
           broker             {:activemq-broker    activemq-broker
@@ -548,7 +550,8 @@
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
       (add-websocket-handler (build-websocket-handlers broker v1-codec) {:route-id :v1})
-      (add-websocket-handler (build-websocket-handlers broker default-codec) {:route-id :vNext})
+      (when (get-route :vNext)
+        (add-websocket-handler (build-websocket-handlers broker default-codec) {:route-id :vNext}))
       broker)))
 
 (s/defn ^:always-validate start

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -9,7 +9,7 @@
 (trapperkeeper/defservice broker-service
   [[:AuthorizationService authorization-check]
    [:ConfigService get-in-config]
-   [:WebroutingService add-websocket-handler get-server]
+   [:WebroutingService add-websocket-handler get-server get-route]
    [:MetricsService get-metrics-registry]
    [:StatusService register-status]]
   (init [this context]
@@ -29,6 +29,7 @@
                                          :find-clients   (partial find-clients inventory)
                                          :authorization-check authorization-check
                                          :get-metrics-registry get-metrics-registry
+                                         :get-route (partial get-route this)
                                          :ssl-cert ssl-cert})]
       (register-status "broker-service"
                        (status-core/get-artifact-version "puppetlabs" "pcp-broker")

--- a/test-resources/conf.d/web-routes.conf
+++ b/test-resources/conf.d/web-routes.conf
@@ -1,1 +1,16 @@
-../../resources/ext/config/conf.d/web-routes.conf
+web-router-service: {
+  "puppetlabs.trapperkeeper.services.status.status-service/status-service": {
+    route: "/status"
+    server: "pcp-broker"
+  }
+  "puppetlabs.pcp.broker.service/broker-service": {
+    v1: {
+      route: "/pcp"
+      server: "pcp-broker"
+    }
+    vNext: {
+      route: "/pcp/vNext"
+      server: "pcp-broker"
+    }
+  }
+}


### PR DESCRIPTION
Here we conditionally guard the mounting of the vNext protocol
handler behind it having a mountpoint present in the web-router
configuration.  This will allow existing users to leave the developing
protocol support disabled until it becomes important enough to make
the configuration of it via webroutes mandatory.

As vNext isn't finalised/public yet, remove it from the default
web-routes.conf that ezbake will publish, and add a more specific
test-resources/conf.d/web-routes.conf.