### PR TITLE
PCP-245 check message expiry consistently

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -223,24 +223,26 @@
 (s/defn ^:always-validate deliver-message
   "Message consumer. Delivers a message to the websocket indicated by the :target field"
   [broker :- Broker capsule :- Capsule]
-  (if-let [websocket (get-websocket broker (:target capsule))]
-    (try
-      (let [connection (get-connection broker websocket)
-            encode (get-in connection [:codec :encode])]
-        (sl/maplog :debug (merge (capsule/summarize capsule)
-                                 (connection/summarize connection)
-                                 {:type :message-delivery})
-                   "Delivering {messageid} for {destination} to {commonname} at {remoteaddress}")
-        (locking websocket
-          (time! (:on-send (:metrics broker))
-                 (let [capsule (capsule/add-hop capsule (broker-uri broker) "deliver")]
-                   (websockets-client/send! websocket (encode (capsule/encode capsule)))))))
-      (catch Exception e
-        (sl/maplog :error e
-                   {:type :message-delivery-error}
-                   "Error in deliver-message")
-        (handle-delivery-failure broker capsule (str e))))
-    (handle-delivery-failure broker capsule "not connected")))
+  (if (capsule/expired? capsule)
+    (process-expired-message broker capsule)
+    (if-let [websocket (get-websocket broker (:target capsule))]
+      (try
+        (let [connection (get-connection broker websocket)
+              encode (get-in connection [:codec :encode])]
+          (sl/maplog :debug (merge (capsule/summarize capsule)
+                                   (connection/summarize connection)
+                                   {:type :message-delivery})
+                     "Delivering {messageid} for {destination} to {commonname} at {remoteaddress}")
+          (locking websocket
+            (time! (:on-send (:metrics broker))
+                   (let [capsule (capsule/add-hop capsule (broker-uri broker) "deliver")]
+                     (websockets-client/send! websocket (encode (capsule/encode capsule)))))))
+        (catch Exception e
+          (sl/maplog :error e
+                     {:type :message-delivery-error}
+                     "Error in deliver-message")
+          (handle-delivery-failure broker capsule (str e))))
+      (handle-delivery-failure broker capsule "not connected"))))
 
 (s/defn ^:always-validate expand-destinations
   "Message consumer.  Takes a message from the accept queue, expands

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -141,8 +141,23 @@
              (activemq/queue-message accept-queue capsule))))
   capsule)
 
+(s/defn ^:always-validate make-ttl_expired-message :- Message
+  "Returns the ttl_expired message advising about the expiry of the given message"
+  [message :- Message]
+  (let [sender (:sender message)
+        in-reply-to (:id message)
+        response_data (->> {:id in-reply-to}
+                           (s/validate p/TTLExpiredMessage))
+        response (-> (message/make-message :message_type "http://puppetlabs.com/ttl_expired"
+                                           :targets [sender]
+                                           :sender "pcp:///server"
+                                           :in-reply-to in-reply-to)
+                     (message/set-expiry 3 :seconds)
+                     (message/set-json-data response_data))]
+    response))
+
 (s/defn ^:always-validate process-expired-message :- Capsule
-  "Reply with a ttl_expired message to the original message sender"
+  "Enqueue a ttl_expired message to the original message sender"
   [broker :- Broker capsule :- Capsule]
   (sl/maplog :trace (assoc (capsule/summarize capsule)
                            :type :message-expired)
@@ -154,16 +169,7 @@
         (sl/maplog :trace {:type :message-expired-from-server}
                    "Server generated message expired.  Dropping")
         capsule)
-      (let [in-reply-to (:id message)
-            response_data {:id in-reply-to}
-            response (-> (message/make-message :message_type "http://puppetlabs.com/ttl_expired"
-                                               :targets [sender]
-                                               :sender "pcp:///server"
-                                               :in-reply-to in-reply-to)
-                         (message/set-expiry 3 :seconds)
-                         (message/set-json-data response_data))]
-        (s/validate p/TTLExpiredMessage response_data)
-        (accept-message-for-delivery broker (capsule/wrap response))))))
+      (accept-message-for-delivery broker (capsule/wrap (make-ttl_expired-message message))))))
 
 (s/defn ^:always-validate retry-delay :- s/Num
   "Compute the delay we should pause for before retrying the delivery of this Capsule"
@@ -285,39 +291,43 @@
 (s/defn ^:always-validate process-associate-message :- Connection
   "Process a session association message on a websocket"
   [broker :- Broker capsule :- Capsule connection :- Connection]
-  (let [request  (:message capsule)
-        id       (:id request)
-        uri      (:sender request)
-        ws       (:websocket connection)
-        encode (get-in connection [:codec :encode])
-        reason   (reason-to-deny-association broker connection uri)
-        response (if reason {:id id :success false :reason reason} {:id id :success true})]
-    (s/validate p/AssociateResponse response)
-    (let [message (-> (message/make-message :message_type "http://puppetlabs.com/associate_response"
-                                            :targets [uri]
-                                            :in-reply-to id
-                                            :sender "pcp:///server")
-                      (message/set-expiry 3 :seconds)
-                      (message/set-json-data response))]
-      (websockets-client/send! ws (encode message)))
-    (if reason
-      (do
-        (websockets-client/close! ws 4002 "association unsuccessful")
-        connection)
-      (let [{:keys [uri-map record-client]} broker]
-        (when-let [old-ws (get-websocket broker uri)]
-          (let [connections (:connections broker)]
-            (sl/maplog :debug (assoc (connection/summarize connection)
-                                     :uri uri
-                                     :type :connection-association-failed)
-                       "Node with uri {uri} already associated with connection {commonname} {remoteaddress}")
-            (websockets-client/close! old-ws 4000 "superceded")
-            (swap! connections dissoc old-ws)))
-        (swap! uri-map assoc uri ws)
-        (record-client uri)
-        (assoc connection
-               :uri uri
-               :state :associated)))))
+    (let [request (:message capsule)
+          id (:id request)
+          ws (:websocket connection)
+          encode (get-in connection [:codec :encode])]
+      (if (capsule/expired? capsule)
+        (let [response (make-ttl_expired-message request)]
+          (websockets-client/send! ws (encode response))
+          connection)
+        (let [uri (:sender request)
+              reason (reason-to-deny-association broker connection uri)
+              response (if reason {:id id :success false :reason reason} {:id id :success true})]
+          (s/validate p/AssociateResponse response)
+          (let [message (-> (message/make-message :message_type "http://puppetlabs.com/associate_response"
+                                                  :targets [uri]
+                                                  :in-reply-to id
+                                                  :sender "pcp:///server")
+                            (message/set-expiry 3 :seconds)
+                            (message/set-json-data response))]
+            (websockets-client/send! ws (encode message)))
+          (if reason
+            (do
+              (websockets-client/close! ws 4002 "association unsuccessful")
+              connection)
+            (let [{:keys [uri-map record-client]} broker]
+              (when-let [old-ws (get-websocket broker uri)]
+                (let [connections (:connections broker)]
+                  (sl/maplog :debug (assoc (connection/summarize connection)
+                                           :uri uri
+                                           :type :connection-association-failed)
+                             "Node with uri {uri} already associated with connection {commonname} {remoteaddress}")
+                  (websockets-client/close! old-ws 4000 "superceded")
+                  (swap! connections dissoc old-ws)))
+              (swap! uri-map assoc uri ws)
+              (record-client uri)
+              (assoc connection
+                     :uri uri
+                     :state :associated)))))))
 
 (s/defn ^:always-validate process-inventory-message :- Connection
   "Process a request for inventory data"

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -405,12 +405,16 @@
 
 (s/defn ^:always-validate connection-associated :- Connection
   [broker :- Broker capsule :- Capsule connection :- Connection]
-  (let [targets (get-in capsule [:message :targets])]
-    (if (= ["pcp:///server"] targets)
-      (process-server-message broker capsule connection)
-      (do
-        (accept-message-for-delivery broker capsule)
-        connection))))
+  (if (capsule/expired? capsule)
+    (do
+      (process-expired-message broker capsule)
+      connection)
+    (let [targets (get-in capsule [:message :targets])]
+      (if (= ["pcp:///server"] targets)
+        (process-server-message broker capsule connection)
+        (do
+          (accept-message-for-delivery broker capsule)
+          connection)))))
 
 (s/defn ^:always-validate determine-next-state :- Connection
   "Determine the next state for a connection given a capsule and some transitions"

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -171,7 +171,7 @@
   (with-app-with-config app broker-services broker-config
     (dotestseq [version protocol-versions]
       (with-open [client (client/connect :certname "client01.example.com"
-                                         :identity "pcp://client02.example.com/test"
+                                         :uri "pcp://client02.example.com/test"
                                          :check-association false
                                          :version version)]
         (let [response (client/recv! client)]
@@ -187,6 +187,16 @@
     (dotestseq [version protocol-versions]
       (with-open [client (client/connect :certname "client01.example.com"
                                          :version version)]))))
+
+(deftest expired-session-association-test
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+      (with-open [client (client/connect :certname "client01.example.com"
+                                         :modify-association #(message/set-expiry % -1 :seconds)
+                                         :check-association false
+                                         :version version)]
+        (let [response (client/recv! client)]
+          (is (= "http://puppetlabs.com/ttl_expired" (:message_type response))))))))
 
 (deftest second-association-new-connection-closes-first-test
   (with-app-with-config app broker-services broker-config

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -366,7 +366,7 @@
           (let [response (client/recv! client)]
             (is (= "http://puppetlabs.com/ttl_expired" (:message_type response)))))))))
 
-(deftest send-expired-explicit-gets-expiry-test
+(deftest send-to-never-connected-will-get-expired-test
   (with-app-with-config app broker-services broker-config
     (dotestseq [version protocol-versions]
       (with-open [client (client/connect :certname "client01.example.com"

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -116,7 +116,8 @@
 
 (deftest deliver-message-test
   (let [broker (make-test-broker)
-        message (message/make-message)
+        message (-> (message/make-message)
+                    (message/set-expiry 3 :seconds))
         capsule (assoc (capsule/wrap message) :target "pcp://example01.example.com/foo")
         failure (atom nil)]
     (with-redefs [puppetlabs.pcp.broker.core/handle-delivery-failure (fn [broker capsule message]

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -342,7 +342,8 @@
 
 (deftest connection-associated-test
   (let [broker (make-test-broker)
-        message (message/make-message :message_type "http://puppetlabs.com/associate_request")
+        message (-> (message/make-message :message_type "http://puppetlabs.com/associate_request")
+                    (message/set-expiry 3 :seconds))
         capsule (capsule/wrap message)
         connection (connection/make-connection "ws1" identity-codec)
         accepted (atom nil)]

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -235,6 +235,11 @@
                              :message_type "http://puppetlabs.com/associate_request"))]
       (is (= false (session-association-message? message))))))
 
+(defn association-capsule
+  [sender seconds]
+  (capsule/wrap (-> (message/make-message :sender sender)
+                    (message/set-expiry seconds :seconds))))
+
 (deftest reason-to-deny-association-test
   (let [broker     (make-test-broker)
         connection (connection/make-connection "websocket" identity-codec)
@@ -251,9 +256,9 @@
   (let [closed (atom (promise))]
     (with-redefs [puppetlabs.experimental.websockets.client/close! (fn [& args] (deliver @closed args))
                   puppetlabs.experimental.websockets.client/send! (constantly false)]
-      (let [message (-> (message/make-message)
-                        (assoc  :sender "pcp://localhost/controller"
-                                :message_type "http://puppetlabs.com/login_message"))
+      (let [message (-> (message/make-message :sender "pcp://localhost/controller"
+                                              :message_type "http://puppetlabs.com/login_message")
+                        (message/set-expiry 3 :seconds))
             capsule (capsule/wrap message)]
         (testing "It should return an associated session"
           (reset! closed (promise))

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -48,11 +48,12 @@
 
 (defn connect
   "Makes a client for testing"
-  [& {:keys [certname identity version check-association]
-      :or {check-association true
+  [& {:keys [certname uri version modify-association check-association]
+      :or {modify-association identity
+           check-association true
            version "vNext"}}]
-  (let [identity            (or identity (str "pcp://" certname "/test"))
-        association-request (make-association-request identity)
+  (let [uri                 (or uri (str "pcp://" certname "/test"))
+        association-request (modify-association (make-association-request uri))
         client              (http-client-with-cert certname)
         message-chan        (chan)
         ws                  (http/websocket client (str "wss://127.0.0.1:8143/pcp/" version)


### PR DESCRIPTION
These set of commits adds the 3 missing checks of message expiry; during association, once associated before persisting the message to the deliver queue, and an consumption of the message from the delivery queue.