### PR TITLE
(maint) Remove Support section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ following command:
 
 Look [here](doc/).
 
-## Support
-
-We use the [Puppet Communications Protocol project on JIRA](https://tickets.puppetlabs.com/browse/PCP)
-with the component `pcp-broker` for tickets on `puppetlabs/pcp-broker`.
-
 ## Maintenance
 
 Maintainers: Alessandro Parisi <alessandro@puppet.com>, Michael Smith


### PR DESCRIPTION
The "Support" section is redundant as we have now the "Maintenance"
section that explains how to fill tickets; with this commit, we remove
"Support".