### PR TITLE
(PCP-470) backport PCP-448: Use ConcurrentHashMap for tracking connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.2
+
+This is a bugfix release
+
+* [PCP-448](https://tickets.puppetlabs.com/browse/PCP-448) Avoid heavy thread
+  contention when disconnecting many clients simultaneously.
+
 ## 0.6.1
 
 This is a bugfix release


### PR DESCRIPTION
Many Jetty threads can result in modifying the connections or uri map.
When many updates occur concurrently, we can see lots of failed atom
updates resulting in much slower processing.

Switch to using a ConcurrentHashMap. It appears to scale better, and is
at least as fast for smaller numbers of clients.