### PR TITLE
(PCP-467) Disable schema validations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,20 @@ And then see [these notes on configuring](doc/configuration.md)
 ## Running the server
 
 For development purposes you can run a broker out of a checkout using
-the *insecure* certificates provided in test-resources/ with the
-following command:
+the *insecure* certificates provided in test-resources/ with either
+the following command:
 
     lein tk
+
+(This one runs the broker with schema validations _disabled_, i.e. the
+same as in production.)
+
+Or with:
+
+    lein tkv
+
+(This one runs the broker with schema validations _enabled_ for greater
+scrutiny.)
 
 ## Documentation
 

--- a/dev-resources/Makefile.i18n
+++ b/dev-resources/Makefile.i18n
@@ -19,6 +19,11 @@ LOCALES=$(basename $(notdir $(wildcard locales/*.po)))
 BUNDLE_DIR=$(subst .,/,$(BUNDLE))
 BUNDLE_FILES=$(patsubst %,resources/$(BUNDLE_DIR)/Messages_%.class,$(MESSAGE_LOCALE) $(LOCALES))
 FIND_SOURCES=find src -name \*.clj
+# xgettext before 0.19 does not understand --add-location=file. Even CentOS
+# 7 ships with an older gettext. We will therefore generate full location
+# info on those systems, and only file names where xgettext supports it
+LOC_OPT=$(shell xgettext --add-location=file -f - </dev/null >/dev/null 2>&1 && echo --add-location=file || echo --add-location)
+
 LOCALES_CLJ=resources/locales.clj
 define LOCALES_CLJ_CONTENTS
 {
@@ -36,24 +41,29 @@ i18n: update-pot msgfmt
 update-pot: locales/messages.pot
 
 locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
-	@tmp=$$(mktemp $@.tmp.XXXX);                                        \
-	$(FIND_SOURCES)                                                     \
-	    | xgettext --from-code=UTF-8 --language=lisp                    \
-	               --copyright-holder 'Puppet <docs@puppet.com>' -F     \
-	               --package-name "$(BUNDLE)"                           \
-	               --package-version "$(BUNDLE_VERSION)"                \
-	               --msgid-bugs-address "docs@puppet.com"               \
-	               -ktrs:1 -ki18n/trs:1                                 \
-	               -ktru:1 -ki18n/tru:1                                 \
-	               -ktrun:1,2 -ki18n/trun:1,2                           \
-	               -ktrsn:1,2 -ki18n/trsn:1,2                           \
-	               --add-comments -o $$tmp -f -;                        \
-	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
-	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
-	if ! diff -q -I POT-Creation-Date $$tmp $@ >& /dev/null; then       \
-	    mv $$tmp $@;                                                    \
-	else                                                                \
-	    rm $$tmp;                                                       \
+	@tmp=$$(mktemp $@.tmp.XXXX);                                            \
+	$(FIND_SOURCES)                                                         \
+	    | xgettext --from-code=UTF-8 --language=lisp                        \
+	               --copyright-holder='Puppet <docs@puppet.com>'            \
+	               --package-name="$(BUNDLE)"                               \
+	               --package-version="$(BUNDLE_VERSION)"                    \
+	               --msgid-bugs-address="docs@puppet.com"                   \
+	               -k                                                       \
+	               -kmark:1 -ki18n/mark:1                                   \
+	               -ktrs:1 -ki18n/trs:1                                     \
+	               -ktru:1 -ki18n/tru:1                                     \
+	               -ktrun:1,2 -ki18n/trun:1,2                               \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                               \
+	               $(LOC_OPT)                                               \
+	               --add-comments --sort-by-file                            \
+	               -o $$tmp -f -;                                           \
+	sed -i.bak -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
+	sed -i.bak -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
+	rm -f $$tmp.bak;                                                        \
+	if ! diff -q -I POT-Creation-Date $$tmp $@ >/dev/null 2>&1; then        \
+	    mv $$tmp $@;                                                        \
+	else                                                                    \
+	    rm $$tmp; touch $@;                                                 \
 	fi
 
 # Run msgfmt over all .po files to generate Java resource bundles

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,9 +1,12 @@
 (ns user
   (:require [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
             [puppetlabs.trapperkeeper.config :as tk-config]
+            [puppetlabs.trapperkeeper.main :as tk-main]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tk-app]
-            [clojure.tools.namespace.repl :as repl]))
+            [clojure.tools.namespace.repl :as repl]
+            [clojure.tools.logging :as log]
+            [schema.core :as s]))
 
 ;; NOTE: in some other projects, where we need to support per-developer config
 ;;  variations, we'll put this code into a namespace called 'user-repl', and
@@ -32,6 +35,13 @@
 (defn go []
   (init)
   (start))
+
+(defn -main
+  "Run trapperkeeper with schema validations enabled"
+  [& args]
+  (s/with-fn-validation
+    (log/info "Running trapperkeeper with schema validations enabled.")
+    (apply tk-main/-main args)))
 
 (defn reset []
   (stop)

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -40,135 +40,135 @@ msgid ""
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/borrowed/mq.clj:249
-msgid "Expected a text message, instead found: {0}"
+msgid "Expected an object implementing either {0} or {1}, instead found: {2}"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:132
+#: src/puppetlabs/pcp/broker/core.clj:125
 msgid ""
 "Authorizing '{messageid}' for '{destination}' - '{allowed}': '{message}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:165
+#: src/puppetlabs/pcp/broker/core.clj:158
 msgid ""
 "Message '{messageid}' for '{destination}' has expired. Sending a ttl_expired."
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:171
+#: src/puppetlabs/pcp/broker/core.clj:164
 msgid "Server generated message expired.  Dropping"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:194
+#: src/puppetlabs/pcp/broker/core.clj:187
 msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:203
+#: src/puppetlabs/pcp/broker/core.clj:196
 msgid "Scheduling message '{messageid}' to be delivered in '{delay}' seconds"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:236
+#: src/puppetlabs/pcp/broker/core.clj:229
 msgid ""
 "Delivering '{messageid}' for '{destination}' to '{commonname}' at "
 "'{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:244
+#: src/puppetlabs/pcp/broker/core.clj:237
 msgid "Error in deliver-message"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:246
+#: src/puppetlabs/pcp/broker/core.clj:239
 msgid "not connected"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:283
+#: src/puppetlabs/pcp/broker/core.clj:276
 msgid "''server'' type connections not accepted"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:291
+#: src/puppetlabs/pcp/broker/core.clj:284
 msgid ""
 "Received session association for '{uri}' from '{commonname}' "
 "'{remoteaddress}'.  Session was already associated as '{existinguri}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:292
+#: src/puppetlabs/pcp/broker/core.clj:285
 msgid "session already associated"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:318
+#: src/puppetlabs/pcp/broker/core.clj:311
 msgid "association unsuccessful"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:326
+#: src/puppetlabs/pcp/broker/core.clj:319
 msgid ""
 "Node with uri '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:327
+#: src/puppetlabs/pcp/broker/core.clj:320
 msgid "superceded"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:364
+#: src/puppetlabs/pcp/broker/core.clj:357
 msgid ""
 "Unhandled message type '{messagetype}' received from '{commonname}' "
 "'{remoteaddr}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:381
-#: src/puppetlabs/pcp/broker/core.clj:454
+#: src/puppetlabs/pcp/broker/core.clj:374
+#: src/puppetlabs/pcp/broker/core.clj:447
 msgid "Broker is not running"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:389
+#: src/puppetlabs/pcp/broker/core.clj:382
 msgid "No client certificate, closing '{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:390
+#: src/puppetlabs/pcp/broker/core.clj:383
 msgid "No client certificate"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:395
+#: src/puppetlabs/pcp/broker/core.clj:388
 msgid "client '{commonname}' connected from '{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:406
+#: src/puppetlabs/pcp/broker/core.clj:399
 msgid ""
 "client '{commonname}' from '{remoteaddress}': cannot accept messages until "
 "session has been associated.  Dropping message."
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:432
+#: src/puppetlabs/pcp/broker/core.clj:425
 msgid "Cannot find transition for state '{state}'"
 msgstr ""
 
 #. TODO(richardc): When we have the message type for
 #. 'authorization_denied' use this instead of
 #. error_message
-#: src/puppetlabs/pcp/broker/core.clj:464
+#: src/puppetlabs/pcp/broker/core.clj:457
 msgid "Message not authorized"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:471
+#: src/puppetlabs/pcp/broker/core.clj:464
 msgid ""
 "Message '{messageid}' for '{destination}' from '{commonname}' "
 "'{remoteaddress}'"
 msgstr ""
 
 #. This is a processing error, say an uncaught exception in any of the stuff we meant to do
-#: src/puppetlabs/pcp/broker/core.clj:476
+#: src/puppetlabs/pcp/broker/core.clj:469
 msgid "Error {0} handling message: {1}"
 msgstr ""
 
 #. TODO(richardc): this could use a different message_type to
 #. indicate an encoding error rather than a processing error
-#: src/puppetlabs/pcp/broker/core.clj:480
+#: src/puppetlabs/pcp/broker/core.clj:473
 msgid "Could not decode message"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:498
+#: src/puppetlabs/pcp/broker/core.clj:491
 msgid "Websocket error '{commonname}' '{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:509
+#: src/puppetlabs/pcp/broker/core.clj:502
 msgid ""
 "client '{commonname}' disconnected from '{remoteaddress}' '{statuscode}' "
 "'{reason}'"

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (def tk-version "1.4.0")
 (def ks-version "1.3.0")
+(def i18n-version "0.4.1")
 
 (defproject puppetlabs/pcp-broker "0.7.1-SNAPSHOT"
   :description "PCP fabric messaging broker"
@@ -72,10 +73,10 @@
                  ;; bridge to allow some spring/activemq stuff to log over slf4j
                  [org.slf4j/jcl-over-slf4j "1.7.10"]
 
-                 [puppetlabs/i18n "0.3.0"]]
+                 [puppetlabs/i18n ~i18n-version]]
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
-            [puppetlabs/i18n "0.3.0"]]
+            [puppetlabs/i18n ~i18n-version]]
 
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}

--- a/project.clj
+++ b/project.clj
@@ -113,6 +113,8 @@
   ; :global-vars {*warn-on-reflection* true}
 
   :aliases {"tk" ["trampoline" "run" "--config" "test-resources/conf.d"]
+            ;; runs trapperkeeper with schema validations enabled
+            "tkv" ["trampoline" "run" "-m" "user" "--config" "test-resources/conf.d"]
             "certs" ["trampoline" "run" "-m" "puppetlabs.pcp.testutils.certs" "--config" "test-resources/conf.d" "--"]
             "cljfmt" ["with-profile" "+cljfmt" "cljfmt"]
             "coverage" ["cloverage" "-e" "puppetlabs.puppetdb.*" "-e" "user"]}

--- a/src/puppetlabs/pcp/broker/activemq.clj
+++ b/src/puppetlabs/pcp/broker/activemq.clj
@@ -13,7 +13,7 @@
 ;; copied into our tree.  If this proves out we should talk to
 ;; puppetdb about extracting puppetlabs.puppetdb.mq into a common library.
 
-(s/defn ^:always-validate queue-message
+(s/defn queue-message
   "Queue a message on a middleware"
   [queue :- s/Str capsule :- Capsule & args]
   (let [mq-spec "vm://pcp?create=false"

--- a/src/puppetlabs/pcp/broker/capsule.clj
+++ b/src/puppetlabs/pcp/broker/capsule.clj
@@ -43,14 +43,14 @@
    :source p/Uri
    :destination (s/either p/Uri [p/Uri])})
 
-(s/defn ^:always-validate -summarize :- CapsuleLog
+(s/defn -summarize :- CapsuleLog
   [capsule :- Capsule]
   {:messageid (get-in capsule [:message :id])
    :source (get-in capsule [:message :sender])
    :destination (or (:target capsule)
                     (get-in capsule [:message :targets]))})
 
-(s/defn ^:always-validate -add-hop :- Capsule
+(s/defn -add-hop :- Capsule
   "Adds a debug hop to the message state"
   ([capsule :- Capsule server :- p/Uri stage :- s/Str]
    (add-hop capsule server stage (ks/timestamp)))
@@ -60,14 +60,14 @@
               :stage  stage}]
      (assoc capsule :hops (conj (vec (:hops capsule)) hop)))))
 
-(s/defn ^:always-validate -expired? :- s/Bool
+(s/defn -expired? :- s/Bool
   "Check whether a message has expired or not"
   [message :- Capsule]
   (let [expires (:expires message)
         now     (time/now)]
     (time/after? now expires)))
 
-(s/defn ^:always-validate -encode :- Message
+(s/defn -encode :- Message
   "Return the Message we should send when sending this Capsule.  Adds
   the debug chunk to the message"
   [capsule :- Capsule]
@@ -76,7 +76,7 @@
     (s/validate p/DebugChunk debug)
     (message/set-json-debug message debug)))
 
-(s/defn ^:always-validate wrap :- Capsule
+(s/defn wrap :- Capsule
   "Wrap a Message producing a Capsule"
   [message :- Message]
   (map->Capsule

--- a/src/puppetlabs/pcp/broker/connection.clj
+++ b/src/puppetlabs/pcp/broker/connection.clj
@@ -42,7 +42,7 @@
   {:commonname (s/maybe s/Str)
    :remoteaddress s/Str})
 
-(s/defn ^:always-validate make-connection :- Connection
+(s/defn make-connection :- Connection
   "Return the initial state for a websocket"
   [websocket :- Websocket codec :- Codec]
   (map->Connection {:state :open
@@ -57,7 +57,7 @@
                                          nil))
                     :created-at (ks/timestamp)}))
 
-(s/defn ^:always-validate -summarize :- ConnectionLog
+(s/defn -summarize :- ConnectionLog
   [connection :- Connection]
   (let [{:keys [common-name remote-address]} connection]
     {:commonname common-name

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -16,7 +16,8 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.logging
              :refer [with-test-logging with-test-logging-debug]]
-            [slingshot.slingshot :refer [throw+ try+]]))
+            [slingshot.slingshot :refer [throw+ try+]]
+            [schema.test :as st]))
 
 (def broker-config
   "A broker with ssl and own spool"
@@ -43,7 +44,8 @@
                                                    :vNext "/pcp/vNext"}
     :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"}
 
-   :metrics {:enabled true}
+   :metrics {:enabled true
+             :server-id "localhost"}
 
    :pcp-broker {:broker-spool "test-resources/tmp/spool"
                 :accept-consumers 2
@@ -63,6 +65,7 @@
   (fs/delete-dir (get-in broker-config [:pcp-broker :broker-spool]))
   (f))
 
+(use-fixtures :once st/validate-schemas)
 (use-fixtures :each cleanup-spool-fixture)
 
 (deftest it-talks-websockets-test

--- a/test/unit/puppetlabs/pcp/broker/activemq_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/activemq_test.clj
@@ -1,5 +1,8 @@
 (ns puppetlabs.pcp.broker.activemq-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.broker.activemq :refer :all]))
+            [puppetlabs.pcp.broker.activemq :refer :all]
+            [schema.test :as st]))
+
+(use-fixtures :once st/validate-schemas)
 
 ;; We're just here to catch simple typos

--- a/test/unit/puppetlabs/pcp/broker/connection_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/connection_test.clj
@@ -1,10 +1,13 @@
 (ns puppetlabs.pcp.broker.connection-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.broker.connection :refer :all]))
+            [puppetlabs.pcp.broker.connection :refer :all]
+            [schema.test :as st]))
 
 (def identity-codec
   {:encode identity
    :decode identity})
+
+(use-fixtures :once st/validate-schemas)
 
 (deftest make-connection-test
   (testing "It returns a map that matches represents a new socket"

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -11,7 +11,7 @@
   (:import (puppetlabs.pcp.broker.connection Connection)
            (java.util.concurrent ConcurrentHashMap)))
 
-(s/defn ^:always-validate make-test-broker :- Broker
+(s/defn make-test-broker :- Broker
   "Return a minimal clean broker state"
   []
   (let [broker {:activemq-broker    "JMSOMGBBQ"
@@ -316,7 +316,7 @@
       (process-server-message broker capsule connection)
       (is (not= nil @associate-request)))))
 
-(s/defn ^:always-validate dummy-connection-from :- Connection
+(s/defn dummy-connection-from :- Connection
   [common-name]
   (assoc (connection/make-connection "ws1" identity-codec)
          :common-name common-name))

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -6,6 +6,7 @@
             [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
             [puppetlabs.pcp.message :as message]
             [schema.core :as s]
+            [schema.test :as st]
             [slingshot.test])
   (:import (puppetlabs.pcp.broker.connection Connection)
            (java.util.concurrent ConcurrentHashMap)))
@@ -34,6 +35,8 @@
 (s/def identity-codec :- Codec
   {:encode identity
    :decode identity})
+
+(use-fixtures :once st/validate-schemas)
 
 (deftest get-broker-cn-test
   (testing "It returns the correct cn"

--- a/test/unit/puppetlabs/pcp/broker/in_memory_inventory_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/in_memory_inventory_test.clj
@@ -1,6 +1,9 @@
 (ns puppetlabs.pcp.broker.in-memory-inventory-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.broker.in-memory-inventory :refer :all]))
+            [puppetlabs.pcp.broker.in-memory-inventory :refer :all]
+            [schema.test :as st]))
+
+(use-fixtures :once st/validate-schemas)
 
 (deftest endpoint-pattern-match?-test
   (testing "direct matches"


### PR DESCRIPTION
In this PR we disable schema validations by default. We achieve that by removing the `^:always-validate` attribute from function definitions in this project.
To compensate for that a new lein alias - `tkv` - is added which is identical to the `tk` alias except it enables the schema validations before it runs trapperkeeper. Additionally the tests are updated to enable the validations by using the `schema.test/validate-schemas` fixture.