### PR TITLE
(PCP-485) Improve inventory response performance

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -17,179 +17,178 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/puppetlabs/pcp/broker/activemq.clj:24
+#: src/puppetlabs/pcp/broker/activemq.clj
 msgid "Delivering message '{messageid}' for '{destination}' to '{queue}' queue"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/activemq.clj:41
+#: src/puppetlabs/pcp/broker/activemq.clj
 msgid "Consuming message '{messageid}' for '{destination}' from '{queue}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/activemq.clj:48
+#: src/puppetlabs/pcp/broker/activemq.clj
 msgid "Error consuming message from '{queue}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/borrowed/mq.clj:38
+#: src/puppetlabs/pcp/broker/borrowed/mq.clj
 msgid "Setting ActiveMQ {0} limit to {1} MB"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/borrowed/mq.clj:136
+#: src/puppetlabs/pcp/broker/borrowed/mq.clj
 msgid ""
 "Caught EOFException on broker startup, trying to restart it again to see if "
 "that solves it. This is probably due to KahaDB corruption."
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/borrowed/mq.clj:249
+#: src/puppetlabs/pcp/broker/borrowed/mq.clj
 msgid "Expected an object implementing either {0} or {1}, instead found: {2}"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:125
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Authorizing '{messageid}' for '{destination}' - '{allowed}': '{message}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:158
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Message '{messageid}' for '{destination}' has expired. Sending a ttl_expired."
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:164
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Server generated message expired.  Dropping"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:187
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:196
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Scheduling message '{messageid}' to be delivered in '{delay}' seconds"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:229
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Delivering '{messageid}' for '{destination}' to '{commonname}' at "
 "'{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:237
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Error in deliver-message"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:239
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "not connected"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:276
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "''server'' type connections not accepted"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:284
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Received session association for '{uri}' from '{commonname}' "
 "'{remoteaddress}'.  Session was already associated as '{existinguri}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:285
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "session already associated"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:311
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "association unsuccessful"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:319
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Node with uri '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:320
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "superceded"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:357
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Unhandled message type '{messagetype}' received from '{commonname}' "
 "'{remoteaddr}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:374
-#: src/puppetlabs/pcp/broker/core.clj:447
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Broker is not running"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:382
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "No client certificate, closing '{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:383
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "No client certificate"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:388
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "client '{commonname}' connected from '{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:399
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "client '{commonname}' from '{remoteaddress}': cannot accept messages until "
 "session has been associated.  Dropping message."
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:425
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Cannot find transition for state '{state}'"
 msgstr ""
 
 #. TODO(richardc): When we have the message type for
 #. 'authorization_denied' use this instead of
 #. error_message
-#: src/puppetlabs/pcp/broker/core.clj:457
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Message not authorized"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:464
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Message '{messageid}' for '{destination}' from '{commonname}' "
 "'{remoteaddress}'"
 msgstr ""
 
 #. This is a processing error, say an uncaught exception in any of the stuff we meant to do
-#: src/puppetlabs/pcp/broker/core.clj:469
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Error {0} handling message: {1}"
 msgstr ""
 
 #. TODO(richardc): this could use a different message_type to
 #. indicate an encoding error rather than a processing error
-#: src/puppetlabs/pcp/broker/core.clj:473
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Could not decode message"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:491
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Websocket error '{commonname}' '{remoteaddress}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/core.clj:502
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "client '{commonname}' disconnected from '{remoteaddress}' '{statuscode}' "
 "'{reason}'"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/service.clj:17
+#: src/puppetlabs/pcp/broker/service.clj
 msgid "Initializing broker service"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/service.clj:41
+#: src/puppetlabs/pcp/broker/service.clj
 msgid "Starting broker service"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/service.clj:44
+#: src/puppetlabs/pcp/broker/service.clj
 msgid "Broker service started"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/service.clj:47
+#: src/puppetlabs/pcp/broker/service.clj
 msgid "Shutting down broker service"
 msgstr ""
 
-#: src/puppetlabs/pcp/broker/service.clj:50
+#: src/puppetlabs/pcp/broker/service.clj
 msgid "Broker service stopped"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/pcp-common "0.5.0"]
+                 [puppetlabs/pcp-common "0.5.1"]
 
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4"]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -331,7 +331,7 @@
   (let [message (:message capsule)
         data (message/get-json-data message)]
     (s/validate p/InventoryRequest data)
-    (let [uris (filter (partial get-websocket broker) ((:find-clients broker) (:query data)))
+    (let [uris (doall (filter (partial get-websocket broker) ((:find-clients broker) (:query data))))
           response-data {:uris uris}
           response (-> (message/make-message :message_type "http://puppetlabs.com/inventory_response"
                                              :targets [(:sender message)]


### PR DESCRIPTION
Gathering inventory responses for multiple query patterns is slow; for
1000 patterns, the response took ~5 seconds. In that particular case,
find-clients was evaluated lazily, and didn't happen until after
creating the response message and setting its expiry time. This resulted
in the message expiring before it was even sent when find-clients took
several seconds.

Force evaluation of find-clients before constructing the response
message, and speed up find-clients for multiple patterns.