### PR TITLE
(PCP-384) Add `/pcp-broker/connect` authz check for association

### DIFF
--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -26,10 +26,12 @@ This would be transformed into the following ring request:
      :form-params {}
      :query-params {"message_type" "http://puppetlabs.com/rpc_blocking_request"
                     "sender" "pcp://client01.example.com/ruby-pcp-client-2251"
-                    "targets" "pcp://client02.example.com/agent"}
+                    "targets" "pcp://client02.example.com/agent"
+                    "destination_report" false}
      :params {"message_type" "http://puppetlabs.com/rpc_blocking_request"
               "sender" "pcp://client01.example.com/ruby-pcp-client-2251"
-              "targets" "pcp://client02.example.com/agent"}}
+              "targets" "pcp://client02.example.com/agent"
+              "destination_report" false}}
 
 And then this can be matched by trapperkeeper-authorization with the following `authorization.conf`.
 
@@ -119,7 +121,8 @@ authorization: {
 
 Not all nodes need or should have access to the full inventory of nodes connected to a PCP broker.
 Inventory requests are one way of acquiring that information; another functionally equivalent way
-to discover all connected nodes is a message using a wildcard to specify the target.
+to discover all connected nodes is a message using a wildcard to specify the target that requests
+a destination report.
 
 Both types of requests can be matched by trapperkeeper-authorization with the following
 `authorization.conf`.
@@ -146,7 +149,7 @@ authorization: {
       sort-order: 400
     },
     {
-      names: "restrict pcp multi-cast"
+      names: "restrict pcp multi-cast destination_report"
       match-request: {
         type: path
         path: "/pcp-broker/send"
@@ -155,6 +158,7 @@ authorization: {
             "pcp://*/agent",
             "pcp://*/*",
           ]
+          destination_report: true
         }
       }
       allow: [

--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -67,5 +67,31 @@ authorization: {
 }
 ```
 
+Session association and inventory requests are handled separately from other PCP Messages, and have
+their own authorization rules. PCP Messages with type `http://puppetlabs.com/associate_request` are
+mapped into ring requests on the `pcp-broker/connect` path. Messages with type
+`http://puppetlabs.com/inventory_request` do not currently have separate authorization, and are
+allowed for any associated client.
+
+Session association requests can be matched by trapperkeeper-authorization with the following `authorization.conf`.
+
+``` HOCON
+# authorization.conf
+authorization: {
+  version: 1
+  rules: [
+    {
+      name: "pcp association"
+      match-request: {
+         type: path
+         path: "/pcp-broker/connect"
+      }
+      allow-unauthenticated: true
+      sort-order: 400
+    },
+  ]
+}
+```
+
 For further notes on how to configure trapperkeeper-authorization see
 https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md

--- a/resources/ext/config/conf.d/authorization.conf
+++ b/resources/ext/config/conf.d/authorization.conf
@@ -4,9 +4,19 @@ authorization: {
     {
       name: "pcp-broker message"
       match-request: {
-         method: post
-         type: path
-         path: "/pcp-broker/send"
+        method: post
+        type: path
+        path: "/pcp-broker/send"
+      }
+      allow-unauthenticated: true
+      sort-order: 400
+    },
+    {
+      name: "pcp-broker association"
+      match-request: {
+        method: post
+        type: path
+        path: "/pcp-broker/connect"
       }
       allow-unauthenticated: true
       sort-order: 400

--- a/resources/ext/config/conf.d/authorization.conf
+++ b/resources/ext/config/conf.d/authorization.conf
@@ -11,15 +11,5 @@ authorization: {
       allow-unauthenticated: true
       sort-order: 400
     },
-    {
-      name: "pcp-broker association"
-      match-request: {
-        method: post
-        type: path
-        path: "/pcp-broker/connect"
-      }
-      allow-unauthenticated: true
-      sort-order: 400
-    },
   ]
 }

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -92,11 +92,12 @@
 
 (s/defn make-ring-request :- ring/Request
   [broker :- Broker capsule :- Capsule websocket :- (s/maybe Websocket)]
-  (let [{:keys [sender targets message_type]} (:message capsule)
+  (let [{:keys [sender targets message_type destination_report]} (:message capsule)
         form-params {}
         query-params {"sender" sender
                       "targets" (if (= 1 (count targets)) (first targets) targets)
-                      "message_type" message_type}
+                      "message_type" message_type
+                      "destination_report" (boolean destination_report)}
         request {:uri "/pcp-broker/send"
                  :request-method :post
                  :remote-addr ""

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -227,17 +227,19 @@
           (let [response (client/recv! client)]
             (is (= [4002 "association unsuccessful"] response))))))))
 
-(def lockdown-broker-config
-  "A broker that allows no connections or messages"
+(def no-assoc-broker-config
+  "A broker that allows no association requests"
   (assoc-in broker-config [:authorization :rules]
             [{:name "deny association"
               :sort-order 400
               :match-request {:type "path"
-                              :path "/pcp-broker/connect"}
+                              :path "/pcp-broker/send"
+                              :query-params {:message_type
+                                             "http://puppetlabs.com/associate_request"}}
               :allow []}]))
 
 (deftest authorization-stops-connections-test
-  (with-app-with-config app broker-services lockdown-broker-config
+  (with-app-with-config app broker-services no-assoc-broker-config
     (dotestseq [version protocol-versions]
       (with-open [client (client/connect :certname "client01.example.com"
                                          :version version
@@ -317,6 +319,38 @@
         (let [response (client/recv! client)]
           (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
           (is (= {:uris []} (message/get-json-data response))))))))
+
+(def no-inventory-broker-config
+  "A broker that allows connections but no inventory requests"
+  (assoc-in broker-config [:authorization :rules]
+            [{:name "allow all"
+              :sort-order 401
+              :match-request {:type "regex"
+                              :path "^/.*$"}
+              :allow-unauthenticated true}
+             {:name "deny inventory"
+              :sort-order 400
+              :match-request {:type "path"
+                              :path "/pcp-broker/send"
+                              :query-params {:message_type
+                                             "http://puppetlabs.com/inventory_request"}}
+              :allow []}]))
+
+(deftest authorization-stops-inventory-test
+  (with-app-with-config app broker-services no-inventory-broker-config
+    (dotestseq [version protocol-versions]
+      (with-open [client (client/connect :certname "client01.example.com"
+                                         :version version)]
+        (testing "cannot request inventory"
+          (let [request (-> (message/make-message)
+                            (assoc :message_type "http://puppetlabs.com/inventory_request"
+                                   :targets ["pcp:///server"]
+                                   :sender "pcp://client01.example.com/test")
+                            (message/set-expiry 3 :seconds)
+                            (message/set-json-data {:query ["pcp://client01.example.com/test"]}))]
+            (client/send! client request)
+            (let [response (client/recv! client 1000)]
+              (is (= nil response)))))))))
 
 ;; Message sending
 (deftest send-to-self-explicit-test
@@ -460,11 +494,6 @@
               :sort-order 420
               :match-request {:type "path"
                               :path "/pcp-broker/send"}
-              :allow-unauthenticated true}
-             {:name "allow association"
-              :sort-order 400
-              :match-request {:type "path"
-                              :path "/pcp-broker/connect"}
               :allow-unauthenticated true}]))
 
 (deftest authorization-will-stop-some-fun-test

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -301,7 +301,8 @@
         capsule (capsule/wrap message)
         connection (connection/make-connection "ws1" identity-codec)
         accepted (atom nil)]
-    (with-redefs [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule] (reset! accepted capsule))]
+    (with-redefs [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule] (reset! accepted capsule))
+                  puppetlabs.pcp.broker.core/authorized? (constantly true)]
       (process-inventory-message broker capsule connection)
       (is (= [] (:uris (message/get-json-data (:message @accepted))))))))
 

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -157,10 +157,12 @@
                 :form-params {}
                 :query-params {"sender" "pcp://example01.example.com/agent"
                                "targets" "pcp://example02.example.com/agent"
-                               "message_type" "example1"}
+                               "message_type" "example1"
+                               "destination_report" false}
                 :params {"sender" "pcp://example01.example.com/agent"
                          "targets" "pcp://example02.example.com/agent"
-                         "message_type" "example1"}}
+                         "message_type" "example1"
+                         "destination_report" false}}
                (make-ring-request broker capsule nil)))))
     (testing "it should return a ring request - two targets"
       (let [message (message/make-message :message_type "example1"
@@ -175,11 +177,32 @@
                 :query-params {"sender" "pcp://example01.example.com/agent"
                                "targets" ["pcp://example02.example.com/agent"
                                           "pcp://example03.example.com/agent"]
-                               "message_type" "example1"}
+                               "message_type" "example1"
+                               "destination_report" false}
                 :params {"sender" "pcp://example01.example.com/agent"
                          "targets" ["pcp://example02.example.com/agent"
                                     "pcp://example03.example.com/agent"]
-                         "message_type" "example1"}}
+                         "message_type" "example1"
+                         "destination_report" false}}
+               (make-ring-request broker capsule nil)))))
+    (testing "it should return a ring request - destination report"
+      (let [message (message/make-message :message_type "example1"
+                                          :sender "pcp://example01.example.com/agent"
+                                          :targets ["pcp://example02.example.com/agent"]
+                                          :destination_report true)
+            capsule (capsule/wrap message)]
+        (is (= {:uri "/pcp-broker/send"
+                :request-method :post
+                :remote-addr ""
+                :form-params {}
+                :query-params {"sender" "pcp://example01.example.com/agent"
+                               "targets" "pcp://example02.example.com/agent"
+                               "message_type" "example1"
+                               "destination_report" true}
+                :params {"sender" "pcp://example01.example.com/agent"
+                         "targets" "pcp://example02.example.com/agent"
+                         "message_type" "example1"
+                         "destination_report" true}}
                (make-ring-request broker capsule nil)))))))
 
 (deftest authorized?-test

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -161,7 +161,7 @@
                 :params {"sender" "pcp://example01.example.com/agent"
                          "targets" "pcp://example02.example.com/agent"
                          "message_type" "example1"}}
-               (make-ring-request broker capsule)))))
+               (make-ring-request broker capsule nil)))))
     (testing "it should return a ring request - two targets"
       (let [message (message/make-message :message_type "example1"
                                           :sender "pcp://example01.example.com/agent"
@@ -180,7 +180,7 @@
                          "targets" ["pcp://example02.example.com/agent"
                                     "pcp://example03.example.com/agent"]
                          "message_type" "example1"}}
-               (make-ring-request broker capsule)))))))
+               (make-ring-request broker capsule nil)))))))
 
 (deftest authorized?-test
   (let [yes-check (fn [r] {:authorized true
@@ -260,7 +260,8 @@
 (deftest process-associate-message-test
   (let [closed (atom (promise))]
     (with-redefs [puppetlabs.experimental.websockets.client/close! (fn [& args] (deliver @closed args))
-                  puppetlabs.experimental.websockets.client/send! (constantly false)]
+                  puppetlabs.experimental.websockets.client/send! (constantly false)
+                  puppetlabs.pcp.broker.core/authorized? (constantly true)]
       (let [message (-> (message/make-message :sender "pcp://localhost/controller"
                                               :message_type "http://puppetlabs.com/login_message")
                         (message/set-expiry 3 :seconds))


### PR DESCRIPTION
Adds a `/pcp-broker/connect` authorization check via tk-auth for
association requests.

Also changes tests to use shorter timeouts when expecting no response.