### PR TITLE
(PCP-487) Increase PCP message expiry in tests

### DIFF
--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -44,7 +44,7 @@
       (assoc :message_type "http://puppetlabs.com/associate_request"
              :targets ["pcp:///server"]
              :sender uri)
-      (message/set-expiry 3 :seconds)))
+      (message/set-expiry 10 :seconds)))
 
 (defn connect
   "Makes a client for testing"


### PR DESCRIPTION
The tests were prone to hitting the expiry limit, especially on slower HW. By increasing the limit we are increasing the chances the tests succeed on such HW.