### PR TITLE
(PCP-506) Make vNext route truly optional

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -68,7 +68,7 @@ The brokers protocol handlers and the status service will need to be mounted usi
 [webrouting](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/webrouting-config.md)
 configuration.
 
-The vNext webroute is optional, and not reccomended for production deployments.
+The vNext webroute is optional, and not recommended for production deployments.
 
 ```
 web-router-service: {

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -173,6 +173,10 @@ msgid ""
 "'{reason}'"
 msgstr ""
 
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "vNext protocol endpoint not configured"
+msgstr ""
+
 #: src/puppetlabs/pcp/broker/service.clj
 msgid "Initializing broker service"
 msgstr ""

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -580,8 +580,12 @@
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
       (add-websocket-handler (build-websocket-handlers broker v1-codec) {:route-id :v1})
-      (when (get-route :vNext)
-        (add-websocket-handler (build-websocket-handlers broker default-codec) {:route-id :vNext}))
+      (try
+        (when (get-route :vNext)
+          (add-websocket-handler (build-websocket-handlers broker default-codec) {:route-id :vNext}))
+        (catch IllegalArgumentException e
+          (sl/maplog :trace {:type :vnext-unavailable}
+                     (i18n/trs "vNext protocol endpoint not configured"))))
       broker)))
 
 (s/defn start

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -543,3 +543,12 @@
                    (:in-reply-to recieved)))
             (is (= "greeting" (:message_type recieved)))
             (is (= "Hello" (message/get-json-data recieved)))))))))
+
+(def no-vnext-config
+  "A broker with vNext unconfigured"
+  (assoc-in broker-config [:web-router-service :puppetlabs.pcp.broker.service/broker-service]
+            {:v1 "/pcp/v1.0"}))
+
+(deftest no-vnext-test
+  (with-app-with-config app broker-services no-vnext-config
+    (is true)))


### PR DESCRIPTION
The vNext route was supposed to be optional, but in practice was not.
Make it truly optional.