### PR TITLE
(PCP-516) CapsuleLog's sender may not be a PCP URI

### DIFF
--- a/src/puppetlabs/pcp/broker/capsule.clj
+++ b/src/puppetlabs/pcp/broker/capsule.clj
@@ -40,7 +40,7 @@
 (def CapsuleLog
   "Schema for a loggable summary of a capsule"
   {:messageid p/MessageId
-   :source p/Uri
+   :source s/Str
    :destination (s/either p/Uri [p/Uri])})
 
 (s/defn -summarize :- CapsuleLog

--- a/test/unit/puppetlabs/pcp/broker/capsule_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/capsule_test.clj
@@ -1,0 +1,45 @@
+(ns puppetlabs.pcp.broker.capsule-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.pcp.broker.capsule :refer :all]
+            [puppetlabs.pcp.message :as message]
+            [puppetlabs.pcp.testutils :refer [dotestseq]]
+            [schema.core :as s]
+            [schema.test :as st]
+            [slingshot.test])
+  (:import [puppetlabs.pcp.broker.capsule Capsule]))
+
+(use-fixtures :once st/validate-schemas)
+
+(deftest wrap-message-test
+  (testing "wrapping a Message in a capsule"
+    (is (instance? Capsule (wrap (message/make-message)))))
+  (testing "fails if an invalid message is given"
+    (is (thrown? Exception (wrap {:things "bad stuff"}))))
+  (testing "does not add any debug hop entry"
+    (is (empty? (:hops (wrap (message/make-message)))))))
+
+(def messages [(message/make-message)
+               (assoc (message/make-message) :sender "pcp://localhost/tester")
+               (assoc (message/make-message) :message_type "bomb")
+               (assoc (message/make-message) :targets ["pcp://localhost/a",
+                                                       "pcp://localhost/b"])])
+
+(deftest summarize-test
+  (dotestseq [msg messages]
+    (testing "can summarize capsules"
+    (let [capsule (wrap msg)]
+      (is (s/validate CapsuleLog (summarize capsule)))))))
+
+(deftest add-hop-test
+  (let [capsule (wrap (message/make-message))]
+    (testing "can add a hop"
+      (let [capsule (add-hop capsule "pcp://server/a" "cooking")]
+        (is (not (empty? (:hops capsule))))))))
+
+(deftest encode-test
+  (let [capsule (wrap (message/make-message))]
+    (testing "can encode without hops"
+      (is (s/validate message/Message (encode capsule))))
+    (testing "can encode with hops"
+      (let [capsule (add-hop capsule "pcp://server/b" "cleaning")]
+        (is (s/validate message/Message (encode capsule)))))))


### PR DESCRIPTION
As the Message schema does not guarantee that :sender is a PCP URI, we
cannot assume that in capsule/summarize, so we define CapsuleLog shcema
with :sender being a string.

Adding a few unit tests for the capsule namespace.