### PR TITLE
(PCP-487) Increase timeouts in tests seriously

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -94,6 +94,12 @@ msgid "session already associated"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
+msgid ""
+"Association request '{messageid}' from '{source}' has expired. Sending a "
+"ttl_expired."
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "association unsuccessful"
 msgstr ""
 

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -67,7 +67,7 @@
 
 (use-fixtures :once st/validate-schemas)
 ; increase ttl set by the `puppetlabs.pcp.message/set-expiry` function
-; 60 times to prevent test failures caused by the expiration of the ttl
+; 5 times to prevent test failures caused by the expiration of the ttl
 ; on messages exchanged during the tests;
 ; we started to see this to happen after we'd enabled the schema
 ; checks globally by using the `schema.test/validate-schemas` fixture,
@@ -76,7 +76,7 @@
                       (let [message-set-expiry message/set-expiry]
                         (with-redefs [message/set-expiry (fn
                                                            ([message number unit]
-                                                            (message-set-expiry message (* 60 number) unit))
+                                                            (message-set-expiry message (* 5 number) unit))
                                                            ([message timestamp]
                                                             (message-set-expiry message timestamp)))]
                           (fn-test)))))

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -25,7 +25,7 @@
     (http/send ws-client :byte bytes))
   (send! [_ message]
     (http/send ws-client :byte (message/encode message)))
-  (recv! [this] (recv! this (* 10 1000)))
+  (recv! [this] (recv! this (* 10 60 1000)))
   (recv! [_ timeout-ms]
     (let [[message channel] (alts!! [message-channel (timeout timeout-ms)])]
       message)))
@@ -44,7 +44,7 @@
       (assoc :message_type "http://puppetlabs.com/associate_request"
              :targets ["pcp:///server"]
              :sender uri)
-      (message/set-expiry 10 :seconds)))
+      (message/set-expiry 5 :seconds)))
 
 (defn connect
   "Makes a client for testing"

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -25,7 +25,7 @@
     (http/send ws-client :byte bytes))
   (send! [_ message]
     (http/send ws-client :byte (message/encode message)))
-  (recv! [this] (recv! this (* 10 60 1000)))
+  (recv! [this] (recv! this (* 10 5 1000)))
   (recv! [_ timeout-ms]
     (let [[message channel] (alts!! [message-channel (timeout timeout-ms)])]
       message)))


### PR DESCRIPTION
This commit increases expiry timeouts on PCP messages exchanged during tests by a factor of 60. This is to avoid occasional failures in CI we keep seeing.
In contrast to previous attempts to do the same this commit doesn't change the actual timeouts but rather redefines the function which applies the timeout values to the PCP messages: `puppetlabs.pcp.message/set-expiry`.
This has the desired effect of raising the timeouts for both the test code and the tested code at the same time (previous attempts were only raising the timeouts in the test code).
Additionally, timeout is also raised in the `puppetlabs.pcp.testutils.client/recv!` function which, too, was causing test failures by not waiting long enough for messages to be received.
Finally the `it-closes-connections-when-not-running-test` test is redesigned such that it avoids another instance of not waiting long enough for the broker to respond.