### PR TITLE
[WIP] (PCP-489) Refactor and improve onMessage handling

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -85,11 +85,15 @@ msgid ""
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "session already associated"
+msgid "Session already associated"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "Invalid associate_request ({reason}); closing '{uri}' WebSocket"
+msgid "Replying to '{requester}' with associate_response: '{rawmsg}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Invalid associate_request ('{reason}'); closing '{uri}' WebSocket"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -106,9 +106,8 @@ msgid ""
 "'{remoteaddress}'"
 msgstr ""
 
-#. TODO(ale): is 'superceded' correct? 'superseded'?
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "superceded"
+msgid "superseded"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -45,16 +45,11 @@ msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid ""
-"Authorizing '{messageid}' for '{destination}' - '{allowed}': '{message}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid ""
 "Message '{messageid}' for '{destination}' has expired. Sending a ttl_expired."
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "Server generated message expired.  Dropping"
+msgid "Server generated message expired; dropping it"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
@@ -86,7 +81,7 @@ msgstr ""
 #: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Received session association for '{uri}' from '{commonname}' "
-"'{remoteaddress}'.  Session was already associated as '{existinguri}'"
+"'{remoteaddress}'. Session was already associated as '{existinguri}'"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
@@ -94,9 +89,7 @@ msgid "session already associated"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid ""
-"Association request '{messageid}' from '{source}' has expired. Sending a "
-"ttl_expired."
+msgid "Invalid associate_request ({reason}); closing '{uri}' WebSocket"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
@@ -105,10 +98,11 @@ msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid ""
-"Node with uri '{uri}' already associated with connection '{commonname}' "
+"Node with URI '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"
 msgstr ""
 
+#. TODO(ale): is 'superceded' correct? 'superseded'?
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "superceded"
 msgstr ""
@@ -117,6 +111,38 @@ msgstr ""
 msgid ""
 "Unhandled message type '{messagetype}' received from '{commonname}' "
 "'{remoteaddr}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid ""
+"Authorizing '{messageid}' for '{destination}' - '{allowed}': '{auth-message}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Processing PCP message: '{rawmsg}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Message not authenticated"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Message not authorized"
+msgstr ""
+
+#. default case
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "unexpected message validation outcome"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Error {0} handling message: {1}"
+msgstr ""
+
+#. TODO(richardc): this could use a different message_type to
+#. indicate an encoding error rather than a processing error
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Could not decode message"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
@@ -133,40 +159,6 @@ msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "client '{commonname}' connected from '{remoteaddress}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid ""
-"client '{commonname}' from '{remoteaddress}': cannot accept messages until "
-"session has been associated.  Dropping message."
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Cannot find transition for state '{state}'"
-msgstr ""
-
-#. TODO(richardc): When we have the message type for
-#. 'authorization_denied' use this instead of
-#. error_message
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Message not authorized"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid ""
-"Message '{messageid}' for '{destination}' from '{commonname}' "
-"'{remoteaddress}'"
-msgstr ""
-
-#. This is a processing error, say an uncaught exception in any of the stuff we meant to do
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Error {0} handling message: {1}"
-msgstr ""
-
-#. TODO(richardc): this could use a different message_type to
-#. indicate an encoding error rather than a processing error
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Could not decode message"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj

--- a/src/puppetlabs/pcp/broker/capsule.clj
+++ b/src/puppetlabs/pcp/broker/capsule.clj
@@ -41,11 +41,13 @@
   "Schema for a loggable summary of a capsule"
   {:messageid p/MessageId
    :source s/Str
+   :messagetype s/Str
    :destination (s/either p/Uri [p/Uri])})
 
 (s/defn -summarize :- CapsuleLog
   [capsule :- Capsule]
   {:messageid (get-in capsule [:message :id])
+   :messagetype (get-in capsule [:message :message_type])
    :source (get-in capsule [:message :sender])
    :destination (or (:target capsule)
                     (get-in capsule [:message :targets]))})

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -283,7 +283,11 @@
   Otherwise, the 'Connection' object's state will be marked as associated and
   returned. Also, in case another WebSocket connection with the same client
   is currently associated, such old connection will be superseded by the new
-  one (i.e. the old connection will be closed by the brocker)."
+  one (i.e. the old connection will be closed by the brocker).
+
+  Note that this function will not update the broker by removing the connection
+  from the 'connections' map, nor the 'uri-map'. It is assumed that such update
+  will be done asynchronously by the onClose handler."
   ;; TODO(ale): make associate_request idempotent when succeed (PCP-521)
   ([broker :- Broker capsule :- Capsule connection :- Connection]
     (let [requester-uri (get-in capsule [:message :sender])

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -260,7 +260,7 @@
                         :existinguri uri
                         :type :connection-already-associated)
           (i18n/trs "Received session association for '{uri}' from '{commonname}' '{remoteaddress}'. Session was already associated as '{existinguri}'"))
-        (i18n/trs "session already associated")))))
+        (i18n/trs "Session already associated")))))
 
 (s/defn process-associate-request! :- (s/maybe Connection)
   "Send an associate_response that will be successfull if:
@@ -297,6 +297,10 @@
                                               :sender "pcp:///server")
                         (message/set-json-data response-data)
                         (message/set-expiry 3 :seconds))]
+        (sl/maplog :debug {:type :associate_response-trace
+                           :requester requester-uri
+                           :rawmsg message}
+                   (i18n/trs "Replying to '{requester}' with associate_response: '{rawmsg}'"))
         (websockets-client/send! ws (encode message)))
       (if reason-to-deny
         (do
@@ -304,7 +308,7 @@
             :debug {:type   :connection-association-failed
                     :uri    requester-uri
                     :reason reason-to-deny}
-            (i18n/trs "Invalid associate_request ({reason}); closing '{uri}' WebSocket"))
+            (i18n/trs "Invalid associate_request ('{reason}'); closing '{uri}' WebSocket"))
           (websockets-client/close! ws 4002 (i18n/trs "association unsuccessful"))
           nil)
         (let [{:keys [uri-map record-client]} broker]
@@ -485,7 +489,7 @@
             message-data (merge (connection/summarize connection)
                                 (capsule/summarize capsule))
             is-association-request (session-association-request? message)]
-        (sl/maplog :trace {:type :message-trace :rawmsg message}
+        (sl/maplog :trace {:type :incoming-message-trace :rawmsg message}
                    (i18n/trs "Processing PCP message: '{rawmsg}'"))
         (try+
           (case (validate-message broker capsule connection is-association-request)

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -37,7 +37,6 @@
    :connections        ConcurrentHashMap ;; Mapping of Websocket session to Connection state
    :metrics-registry   Object
    :metrics            {s/Keyword Object}
-   :transitions        {ConnectionState IFn}
    :broker-cn          s/Str
    :state              Atom})
 
@@ -90,54 +89,18 @@
   [broker :- Broker uri :- p/Uri]
   (get (:uri-map broker) uri))
 
-(s/defn make-ring-request :- ring/Request
-  [broker :- Broker capsule :- Capsule websocket :- (s/maybe Websocket)]
-  (let [{:keys [sender targets message_type destination_report]} (:message capsule)
-        form-params {}
-        query-params {"sender" sender
-                      "targets" (if (= 1 (count targets)) (first targets) targets)
-                      "message_type" message_type
-                      "destination_report" (boolean destination_report)}
-        request {:uri "/pcp-broker/send"
-                 :request-method :post
-                 :remote-addr ""
-                 :form-params form-params
-                 :query-params query-params
-                 :params (merge query-params form-params)}]
-    ;; some things we can only know when sender is connected
-    (if websocket
-      (let [remote-addr (.. websocket (getSession) (getRemoteAddress) (toString))
-            ssl-client-cert (first (websockets-client/peer-certs websocket))]
-        (merge request {:remote-addr remote-addr
-                        :ssl-client-cert ssl-client-cert}))
-      request)))
-
-(s/defn authorized? :- s/Bool
-  "Check if the message is authorized"
-  ([broker :- Broker capsule :- Capsule]
-   (if-let [websocket (get-websocket broker (get-in capsule [:message :sender]))]
-     (authorized? broker capsule websocket)
-     (authorized? broker capsule nil)))
-  ([broker :- Broker capsule :- Capsule websocket :- (s/maybe Websocket)]
-   (let [ring-request (make-ring-request broker capsule websocket)
-         {:keys [authorization-check]} broker]
-     (let [{:keys [authorized message]} (authorization-check ring-request)
-           allowed (boolean authorized)]
-       (sl/maplog :trace (assoc (capsule/summarize capsule)
-                                :type :message-authorization
-                                :allowed allowed
-                                :message message)
-                  (i18n/trs "Authorizing '{messageid}' for '{destination}' - '{allowed}': '{message}'"))
-       allowed))))
+;;
+;; Message queueing and processing
+;;
 
 ;; message lifecycle
 (s/defn accept-message-for-delivery :- Capsule
-  "Accept a message for later delivery"
+  "Add a debug hop entry to the specified capsule and accept a message
+   for later delivery. Return the modified capsule."
   [broker :- Broker capsule :- Capsule]
-  (if (authorized? broker capsule)
-    (time! (:message-queueing (:metrics broker))
-           (let [capsule (capsule/add-hop capsule (broker-uri broker) "accept-to-queue")]
-             (activemq/queue-message accept-queue capsule))))
+  (time! (:message-queueing (:metrics broker))
+         (let [capsule (capsule/add-hop capsule (broker-uri broker) "accept-to-queue")]
+           (activemq/queue-message accept-queue capsule)))
   capsule)
 
 (s/defn make-ttl_expired-message :- Message
@@ -146,6 +109,7 @@
   (let [sender (:sender message)
         in-reply-to (:id message)
         response_data (->> {:id in-reply-to}
+                           ;; TODO(ale): consider removing s/validate; we create it, why validate?
                            (s/validate p/TTLExpiredMessage))
         response (-> (message/make-message :message_type "http://puppetlabs.com/ttl_expired"
                                            :targets [sender]
@@ -156,17 +120,20 @@
     response))
 
 (s/defn process-expired-message :- Capsule
-  "Enqueue a ttl_expired message to the original message sender"
+  "Enqueue a ttl_expired message to the original message sender, in case the
+   sender is not `pcp:///sender`, otherwise drop the message.
+   Return the processed capsule."
   [broker :- Broker capsule :- Capsule]
-  (sl/maplog :trace (assoc (capsule/summarize capsule)
-                           :type :message-expired)
-             (i18n/trs "Message '{messageid}' for '{destination}' has expired. Sending a ttl_expired."))
+  (sl/maplog
+    :trace (assoc (capsule/summarize capsule)
+                  :type :message-expired)
+    (i18n/trs "Message '{messageid}' for '{destination}' has expired. Sending a ttl_expired."))
   (let [message (:message capsule)
         sender  (:sender message)]
     (if (= "pcp:///server" sender)
       (do
         (sl/maplog :trace {:type :message-expired-from-server}
-                   (i18n/trs "Server generated message expired.  Dropping"))
+                   (i18n/trs "Server generated message expired; dropping it"))
         capsule)
       (accept-message-for-delivery broker (capsule/wrap (make-ttl_expired-message message))))))
 
@@ -195,10 +162,11 @@
     (if (time/after? expires now)
       (let [retry-delay (retry-delay capsule)
             capsule     (capsule/add-hop capsule (broker-uri broker) "redelivery")]
-        (sl/maplog :trace (assoc (capsule/summarize capsule)
-                                 :type :message-redelivery
-                                 :delay retry-delay)
-                   (i18n/trs "Scheduling message '{messageid}' to be delivered in '{delay}' seconds"))
+        (sl/maplog
+          :trace (assoc (capsule/summarize capsule)
+                        :type :message-redelivery
+                        :delay retry-delay)
+          (i18n/trs "Scheduling message '{messageid}' to be delivered in '{delay}' seconds"))
         (time! (:message-queueing (:metrics broker))
                (activemq/queue-message delivery-queue capsule (mq/delay-property retry-delay :seconds))))
       (process-expired-message broker capsule))))
@@ -209,6 +177,7 @@
   (when (:destination_report message)
     (let [report {:id (:id message)
                   :targets targets}]
+      ;; TODO(ale): consider removing s/validate; we create it, why validate?
       (s/validate p/DestinationReport report)
       (accept-message-for-delivery
         broker
@@ -230,10 +199,11 @@
       (try
         (let [connection (get-connection broker websocket)
               encode (get-in connection [:codec :encode])]
-          (sl/maplog :debug (merge (capsule/summarize capsule)
-                                   (connection/summarize connection)
-                                   {:type :message-delivery})
-                     (i18n/trs "Delivering '{messageid}' for '{destination}' to '{commonname}' at '{remoteaddress}'"))
+          (sl/maplog
+            :debug (merge (capsule/summarize capsule)
+                          (connection/summarize connection)
+                          {:type :message-delivery})
+            (i18n/trs "Delivering '{messageid}' for '{destination}' to '{commonname}' at '{remoteaddress}'"))
           (locking websocket
             (time! (:on-send (:metrics broker))
                    (let [capsule (capsule/add-hop capsule (broker-uri broker) "deliver")]
@@ -246,7 +216,7 @@
       (handle-delivery-failure broker capsule (i18n/trs "not connected")))))
 
 (s/defn expand-destinations
-  "Message consumer.  Takes a message from the accept queue, expands
+  "Message consumer. Takes a message from the accept queue, expands
   destinations, and enqueues to the `delivery-queue`"
   [broker :- Broker capsule :- Capsule]
   (let [message   (:message capsule)
@@ -267,12 +237,13 @@
             (concat (activemq/subscribe-to-queue accept-queue (partial expand-destinations broker) accept-consumers)
                     (activemq/subscribe-to-queue delivery-queue (partial deliver-message broker) delivery-consumers)))))
 
-(s/defn session-association-message? :- s/Bool
+(s/defn session-association-request? :- s/Bool
   "Return true if message is a session association message"
   [message :- Message]
   (and (= (:targets message) ["pcp:///server"])
        (= (:message_type message) "http://puppetlabs.com/associate_request")))
 
+;; process-associate-request! helper
 (s/defn reason-to-deny-association :- (s/maybe s/Str)
   "Returns an error message describing why the session should not be
   allowed, if it should be denied"
@@ -281,216 +252,319 @@
     (cond
       (= type "server")
       (i18n/trs "''server'' type connections not accepted")
-
       (= :associated (:state connection))
       (let [{:keys [uri]} connection]
-        (sl/maplog :debug (assoc (connection/summarize connection)
-                                 :uri as
-                                 :existinguri uri
-                                 :type :connection-already-associated)
-                   (i18n/trs "Received session association for '{uri}' from '{commonname}' '{remoteaddress}'.  Session was already associated as '{existinguri}'"))
+        (sl/maplog
+          :debug (assoc (connection/summarize connection)
+                        :uri as
+                        :existinguri uri
+                        :type :connection-already-associated)
+          (i18n/trs "Received session association for '{uri}' from '{commonname}' '{remoteaddress}'. Session was already associated as '{existinguri}'"))
         (i18n/trs "session already associated")))))
 
-(s/defn process-associate-message :- Connection
-  "Process a session association message on a websocket"
-  [broker :- Broker capsule :- Capsule connection :- Connection]
-  (let [ws (:websocket connection)]
-    (if (authorized? broker capsule ws)
-      (let [request (:message capsule)
-            id (:id request)
-            encode (get-in connection [:codec :encode])]
-        (if (capsule/expired? capsule)
-          (do
-            (sl/maplog :trace (assoc (capsule/summarize capsule)
-                                :type :message-expired)
-                       (i18n/trs "Association request '{messageid}' from '{source}' has expired. Sending a ttl_expired."))
-            (let [response (make-ttl_expired-message request)]
-              (websockets-client/send! ws (encode response))
-              connection))
-          (let [uri (:sender request)
-                reason (reason-to-deny-association broker connection uri)
-                response (if reason {:id id :success false :reason reason} {:id id :success true})]
-            (s/validate p/AssociateResponse response)
-            (let [message (-> (message/make-message :message_type "http://puppetlabs.com/associate_response"
-                                                    :targets [uri]
-                                                    :in-reply-to id
-                                                    :sender "pcp:///server")
-                              (message/set-json-data response)
-                              (message/set-expiry 3 :seconds))]
-              (websockets-client/send! ws (encode message)))
-            (if reason
-              (do
-                (websockets-client/close! ws 4002 (i18n/trs "association unsuccessful"))
-                connection)
-              (let [{:keys [uri-map record-client]} broker]
-                (when-let [old-ws (get-websocket broker uri)]
-                  (let [connections (:connections broker)]
-                    (sl/maplog :debug (assoc (connection/summarize connection)
-                                             :uri uri
-                                             :type :connection-association-failed)
-                               (i18n/trs "Node with uri '{uri}' already associated with connection '{commonname}' '{remoteaddress}'"))
-                    (websockets-client/close! old-ws 4000 (i18n/trs "superceded"))
-                    (.remove connections old-ws)))
-                (.put uri-map uri ws)
-                (record-client uri)
-                (assoc connection
-                       :uri uri
-                       :state :associated))))))
-      (do
-        (websockets-client/close! ws 4002 (i18n/trs "association unsuccessful"))
-        connection))))
+(s/defn process-associate-request! :- (s/maybe Connection)
+  "Send an associate_response that will be successfull if:
+    - a reason-to-deny is not specified as an argument nor determined by
+      reason-to-deny-association;
+    - the requester `client_type` is not `server`;
+    - the specified WebSocket connection has not been associated previously.
+  If the request gets denied, the WebSocket connection will be closed and the
+  function returns nil.
+  Otherwise, the 'Connection' object's state will be marked as associated and
+  returned. Also, in case another WebSocket connection with the same client
+  is currently associated, such old connection will be superseded by the new
+  one (i.e. the old connection will be closed by the brocker)."
+  ;; TODO(ale): make associate_request idempotent when succeed (PCP-521)
+  ([broker :- Broker capsule :- Capsule connection :- Connection]
+    (let [requester-uri (get-in capsule [:message :sender])
+          reason-to-deny (reason-to-deny-association broker connection requester-uri)]
+      (process-associate-request! broker capsule connection reason-to-deny)))
+  ([broker :- Broker capsule :- Capsule connection :- Connection reason-to-deny :- (s/maybe s/Str)]
+    ;; NB(ale): don't validate the associate_request as there's no data chunk...
+    (let [ws (:websocket connection)
+          request (:message capsule)
+          id (:id request)
+          encode (get-in connection [:codec :encode])
+          requester-uri (:sender request)
+          response-data (if reason-to-deny
+                          {:id id :success false :reason reason-to-deny}
+                          {:id id :success true})]
+      ;; TODO(ale): consider removing s/validate; we create it, why validate?
+      (s/validate p/AssociateResponse response-data)
+      (let [message (-> (message/make-message :message_type "http://puppetlabs.com/associate_response"
+                                              :targets [requester-uri]
+                                              :in-reply-to id
+                                              :sender "pcp:///server")
+                        (message/set-json-data response-data)
+                        (message/set-expiry 3 :seconds))]
+        (websockets-client/send! ws (encode message)))
+      (if reason-to-deny
+        (do
+          (sl/maplog
+            :debug {:type   :connection-association-failed
+                    :uri    requester-uri
+                    :reason reason-to-deny}
+            (i18n/trs "Invalid associate_request ({reason}); closing '{uri}' WebSocket"))
+          (websockets-client/close! ws 4002 (i18n/trs "association unsuccessful"))
+          nil)
+        (let [{:keys [uri-map record-client]} broker]
+          (when-let [old-ws (get-websocket broker requester-uri)]
+            (let [connections (:connections broker)]
+              (sl/maplog
+                :debug (assoc (connection/summarize connection)
+                         :uri requester-uri
+                         :type :connection-association-failed)
+                (i18n/trs "Node with URI '{uri}' already associated with connection '{commonname}' '{remoteaddress}'"))
+              ;; TODO(ale): is 'superceded' correct? 'superseded'?
+              (websockets-client/close! old-ws 4000 (i18n/trs "superceded"))
+              (.remove connections old-ws)))
+          (.put uri-map requester-uri ws)
+          (record-client requester-uri)
+          (assoc connection
+            :uri requester-uri
+            :state :associated))))))
 
-(s/defn process-inventory-message :- Connection
-  "Process a request for inventory data"
+(s/defn process-inventory-request
+  "Process a request for inventory data.
+   This function assumes that the requester client is associated.
+   Returns nil."
   [broker :- Broker capsule :- Capsule connection :- Connection]
-  (if (authorized? broker capsule (:websocket connection))
-    (let [message (:message capsule)
-          data (message/get-json-data message)]
-      (s/validate p/InventoryRequest data)
-      (let [uris (doall (filter (partial get-websocket broker) ((:find-clients broker) (:query data))))
-            response-data {:uris uris}]
-        (s/validate p/InventoryResponse response-data)
-        (accept-message-for-delivery
-          broker
-          (-> (message/make-message :message_type "http://puppetlabs.com/inventory_response"
-                                    :targets [(:sender message)]
-                                    :in-reply-to (:id message)
-                                    :sender "pcp:///server")
-              (message/set-json-data response-data)
-              ;; set expiration last so if any of the previous steps take significant time
-              ;; the message doesn't expire
-              (message/set-expiry 3 :seconds)
-              (capsule/wrap))))))
-  connection)
+  (assert (= (:state connection) :associated))
+  (let [message (:message capsule)
+        data (message/get-json-data message)]
+    (s/validate p/InventoryRequest data)
+    (let [uris (doall (filter (partial get-websocket broker) ((:find-clients broker) (:query data))))
+          response-data {:uris uris}]
+      ;; TODO(ale): consider removing s/validate; we create it, why validate?
+      (s/validate p/InventoryResponse response-data)
+      (accept-message-for-delivery
+        broker
+        (-> (message/make-message :message_type "http://puppetlabs.com/inventory_response"
+                                  :targets [(:sender message)]
+                                  :in-reply-to (:id message)
+                                  :sender "pcp:///server")
+            (message/set-json-data response-data)
+            ;; set expiration last so if any of the previous steps take
+            ;; significant time the message doesn't expire
+            (message/set-expiry 3 :seconds)
+            (capsule/wrap)))))
+  nil)
 
-(s/defn process-server-message :- Connection
+(s/defn process-server-message! :- (s/maybe Connection)
   "Process a message directed at the middleware"
   [broker :- Broker capsule :- Capsule connection :- Connection]
   (let [message-type (get-in capsule [:message :message_type])]
     (case message-type
-      "http://puppetlabs.com/associate_request" (process-associate-message broker capsule connection)
-      "http://puppetlabs.com/inventory_request" (process-inventory-message broker capsule connection)
+      "http://puppetlabs.com/associate_request" (process-associate-request! broker capsule connection)
+      "http://puppetlabs.com/inventory_request" (process-inventory-request broker capsule connection)
       (do
         (sl/maplog :debug (assoc (connection/summarize connection)
                                  :messagetype message-type
                                  :type :broker-unhandled-message)
-                   (i18n/trs "Unhandled message type '{messagetype}' received from '{commonname}' '{remoteaddr}'"))))))
+                   (i18n/trs "Unhandled message type '{messagetype}' received from '{commonname}' '{remoteaddr}'"))
+        connection))))
 
-(s/defn check-sender-matches :- s/Bool
-  "Validate that the cert name advertised by the sender matches the cert name in the certificate"
+;;
+;; Message validation
+;;
+
+(s/defn make-ring-request :- ring/Request
+  [message :- Message websocket :- (s/maybe Websocket)]
+  (let [{:keys [sender targets message_type destination_report]} message
+        form-params {}
+        query-params {"sender" sender
+                      "targets" (if (= 1 (count targets)) (first targets) targets)
+                      "message_type" message_type
+                      "destination_report" (boolean destination_report)}
+        request {:uri "/pcp-broker/send"
+                 :request-method :post
+                 :remote-addr ""
+                 :form-params form-params
+                 :query-params query-params
+                 :params (merge query-params form-params)}]
+    ;; some things we can only know when sender is connected
+    (if websocket
+      (let [remote-addr (.. websocket (getSession) (getRemoteAddress) (toString))
+            ssl-client-cert (first (websockets-client/peer-certs websocket))]
+        (merge request {:remote-addr remote-addr
+                        :ssl-client-cert ssl-client-cert}))
+      request)))
+
+;; NB(ale): using (s/Maybe Websocket) in the signature for the sake of testing
+(s/defn authorized? :- s/Bool
+  "Check if the message is authorized"
+  [broker :- Broker pcp-message :- Message websocket :- (s/maybe Websocket)]
+  (let [ring-request (make-ring-request pcp-message websocket)
+        {:keys [authorization-check]} broker
+        {:keys [authorized message]} (authorization-check ring-request)
+        allowed (boolean authorized)]
+    (sl/maplog
+      :trace {:messageid    (:id pcp-message)
+              :source       (:sender pcp-message)
+              :destination  (:targets pcp-message)
+              :type         :message-authorization
+              :allowed      allowed
+              :auth-message message}
+      (i18n/trs "Authorizing '{messageid}' for '{destination}' - '{allowed}': '{auth-message}'"))
+    allowed))
+
+(s/defn authenticated? :- s/Bool
+  "Check if the cert name advertised by the sender matches the cert name
+   in the certificate"
   [message :- Message connection :- Connection]
   (let [{:keys [common-name]} connection
         {:keys [sender]} message
         [client] (p/explode-uri sender)]
     (= client common-name)))
 
-;; Websocket event handlers
+(def MessageValidationOutcome
+  "Outcome of validate-message"
+  (s/enum :to-be-ignored-during-association
+          :not-authenticated
+          :not-authorized
+          :expired
+          :to-be-processed))
 
-(defn- on-connect!
-  "OnConnect websocket event handler"
-  [broker codec ws]
-  (time! (:on-connect (:metrics broker))
-         (if-not (= :running @(:state broker))
-           (websockets-client/close! ws 1011 (i18n/trs "Broker is not running"))
-           (let [connection (add-connection! broker ws codec)
-                 {:keys [common-name]} connection
-                 idle-timeout (* 1000 60 15)]
-             (if (nil? common-name)
-               (do
-                 (sl/maplog :debug (assoc (connection/summarize connection)
-                                          :type :connection-no-peer-certificate)
-                            (i18n/trs "No client certificate, closing '{remoteaddress}'"))
-                 (websockets-client/close! ws 4003 (i18n/trs "No client certificate")))
-               (do
-                 (websockets-client/idle-timeout! ws idle-timeout)
-                 (sl/maplog :debug (assoc (connection/summarize connection)
-                                          :type :connection-open)
-                            (i18n/trs "client '{commonname}' connected from '{remoteaddress}'"))))))))
+(s/defn validate-message :- MessageValidationOutcome
+  "Determine whether the specified message should be processed by checking,
+   in order, if the message: 1) is an associate-request as expected during
+   Session Association; 2) is authenticated; 3) is authorized; 4) expired"
+  [broker :- Broker capsule :- Capsule connection :- Connection is-association-request :- s/Bool]
+  (if (and (= :open (:state connection)) (not is-association-request))
+    :to-be-ignored-during-association
+    (let [message (:message capsule)
+          ws (:websocket connection)]
+      (if-not (authenticated? message connection)
+        :not-authenticated
+        (if-not (authorized? broker message ws)
+          :not-authorized
+          (if (capsule/expired? capsule)
+            :expired
+            :to-be-processed))))))
 
-(s/defn connection-open :- Connection
-  [broker :- Broker capsule :- Capsule connection :- Connection]
-  (let [message (:message capsule)]
-    (if (session-association-message? message)
-      (process-associate-message broker capsule connection)
-      (do
-        (sl/maplog :warn (merge (connection/summarize connection)
-                                (capsule/summarize capsule)
-                                {:type :connection-message-before-association})
-                   (i18n/trs "client '{commonname}' from '{remoteaddress}': cannot accept messages until session has been associated.  Dropping message."))
-        connection))))
-
-(s/defn connection-associated :- Connection
-  [broker :- Broker capsule :- Capsule connection :- Connection]
-  (if (capsule/expired? capsule)
-    (do
-      (process-expired-message broker capsule)
-      connection)
-    (let [targets (get-in capsule [:message :targets])]
-      (if (= ["pcp:///server"] targets)
-        (process-server-message broker capsule connection)
-        (do
-          (accept-message-for-delivery broker capsule)
-          connection)))))
-
-(s/defn determine-next-state :- Connection
-  "Determine the next state for a connection given a capsule and some transitions"
-  [broker :- Broker capsule :- Capsule connection :- Connection]
-  (let [transitions (:transitions broker)
-        state       (:state connection)]
-    (if-let [transition (get transitions state)]
-      (transition broker capsule connection)
-      (do
-        (sl/maplog :error {:type :broker-state-transition-unknown
-                           :state state}
-                   (i18n/trs "Cannot find transition for state '{state}'"))
-        connection))))
+;;
+;; WebSocket onMessage handling
+;;
 
 (s/defn send-error-message
-  [message :- (s/maybe Message) description :- String connection :- Connection]
-  (let [body {:description description}
-        error (-> (message/make-message
-                     :message_type "http://puppetlabs.com/error_message"
-                     :sender "pcp:///server")
-                    (message/set-json-data body))
-        error (if message
-                (assoc error :in-reply-to (:id message))
-                error)
+  [in-reply-to-message :- (s/maybe Message) description :- String connection :- Connection]
+  (let [data-content {:description description}
+        error-msg (-> (message/make-message :message_type "http://puppetlabs.com/error_message"
+                                            :sender "pcp:///server")
+                      (message/set-json-data data-content))
+        error-msg (if in-reply-to-message
+                    (assoc error-msg :in-reply-to (:id in-reply-to-message))
+                    error-msg)
         {:keys [codec websocket]} connection
         encode (:encode codec)]
-    (s/validate p/ErrorMessage body)
-    (websockets-client/send! websocket (encode error))))
+    ;; TODO(ale): consider removing s/validate; we create it, why validate?
+    (s/validate p/ErrorMessage data-content)
+    (websockets-client/send! websocket (encode error-msg))
+    nil))
+
+(defn log-access
+  [lvl message-data]
+  (sl/maplog
+    [:puppetlabs.pcp.broker.pcp_access lvl]
+    message-data
+    "{accessoutcome} {remoteaddress} {commonname} {source} {messagetype} {messageid} {destination}"))
+
+;; NB(ale): using (s/Maybe Websocket) in the signature for the sake of testing
+(s/defn process-message! :- (s/maybe Connection)
+  "Deserialize, validate (authentication, authorization, and expiration), and
+  process the specified raw message. Return the 'Connection' object associated
+  to the specified 'Websocket' in case it gets modified (hence the '!' in the
+  function name), otherwise nil.
+  Also, log the message validation outcome via 'pcp-access' logger."
+  [broker :- Broker bytes :- message/ByteArray ws :- (s/maybe Websocket)]
+  (let [connection (get-connection broker ws)
+        decode (get-in connection [:codec :decode])]
+    (try+
+      (let [message (decode bytes)
+            capsule (capsule/wrap message)
+            message-data (merge (connection/summarize connection)
+                                (capsule/summarize capsule))
+            is-association-request (session-association-request? message)]
+        (sl/maplog :trace {:type :message-trace :rawmsg message}
+                   (i18n/trs "Processing PCP message: '{rawmsg}'"))
+        (try+
+          (case (validate-message broker capsule connection is-association-request)
+            :to-be-ignored-during-association
+            (log-access :warn (assoc message-data :accessoutcome "IGNORED_DURING_ASSOCIATION"))
+            :not-authenticated
+            (let [not-authenticated-msg (i18n/trs "Message not authenticated")]
+              (log-access :warn (assoc message-data :accessoutcome "AUTHENTICATION_FAILURE"))
+              (if is-association-request
+                ;; send an unsuccessful associate_response and close the WebSocket
+                ;; TODO(ale): new behaviour; previously the broker would send a
+                ;; PCP error without closing the connection; ensure it's ok
+                (process-associate-request! broker capsule connection not-authenticated-msg)
+                (send-error-message message not-authenticated-msg connection)))
+            :not-authorized
+            (let [not-authorized-msg (i18n/trs "Message not authorized")]
+              (log-access :warn (assoc message-data :accessoutcome "AUTHORIZATION_FAILURE"))
+              (if is-association-request
+                ;; send an unsuccessful associate_response and close the WebSocket
+                ;; TODO(ale): new behaviour; previously the broker would only
+                ;; close the connection; ensure it's ok
+                (process-associate-request! broker capsule connection not-authorized-msg)
+                ;; TODO(ale): use 'unauthorized' in version 2
+                (send-error-message message not-authorized-msg connection)))
+            :expired
+            (do
+              (log-access :warn (assoc message-data :accessoutcome "EXPIRED"))
+              (if is-association-request
+                ;; send back the ttl-expired immediately, without queueing
+                (let [response (make-ttl_expired-message message)
+                      encode (get-in connection [:codec :encode])]
+                  (websockets-client/send! ws (encode response)))
+                (process-expired-message broker capsule))
+              nil)
+            :to-be-processed
+            (do
+              (log-access :info (assoc message-data :accessoutcome "AUTHORIZATION_SUCCESS"))
+              (let [uri (broker-uri broker)
+                    capsule (capsule/add-hop capsule uri "accepted")]
+                (if (= (:targets message) ["pcp:///server"])
+                  (process-server-message! broker capsule connection)
+                  (do
+                    (assert (= (:state connection) :associated))
+                    (accept-message-for-delivery broker capsule)
+                    nil))))
+            ;; default case
+            (assert false (i18n/trs "unexpected message validation outcome")))
+          (catch map? m
+            ;; TODO(ale): this may log a duplicate pcp-access entry for the
+            ;; same received message; ensure we're happy with that
+            (log-access :error (assoc message-data :accessoutcome "PROCESSING_ERROR"))
+            ;; This is a processing error, say an uncaught exception in
+            ;; any of the stuff we meant to do
+            (send-error-message
+              message
+              (i18n/trs "Error {0} handling message: {1}" (:type m) (:message &throw-context))
+              connection))))
+      (catch map? m
+        (sl/maplog
+          [:puppetlabs.pcp.broker.pcp_access :warn]
+          (assoc (connection/summarize connection) :type :deserialization-failure
+                                                   :outcome "DESERIALIZATION_ERROR")
+          "{outcome} {remoteaddress} {commonname} unknown unknown unknown unknown unknown")
+        ;; TODO(richardc): this could use a different message_type to
+        ;; indicate an encoding error rather than a processing error
+        (send-error-message nil (i18n/trs "Could not decode message") connection)))))
 
 (defn on-message!
+  "If the broker service is not running, close the WebSocket connection.
+   Otherwise process the message and, in case a 'Connection' object is
+   returned, updates the related broker's 'connections' map entry."
   [broker ws bytes]
-  (time! (:on-message (:metrics broker))
-         (if-not (= :running @(:state broker))
-           (websockets-client/close! ws 1011 (i18n/trs "Broker is not running"))
-           (let [connection (get-connection broker ws)
-                 decode (get-in connection [:codec :decode])]
-             (try+
-              (let [message (decode bytes)]
-                (try+
-                 (if-not (check-sender-matches message connection)
-                   ;; TODO(richardc): When we have the message type for
-                   ;; 'authorization_denied' use this instead of
-                   ;; error_message
-                   (send-error-message message (i18n/trs "Message not authorized") connection)
-                   (let [uri (broker-uri broker)
-                         capsule (capsule/wrap message)
-                         capsule (capsule/add-hop capsule uri "accepted")]
-                     (sl/maplog :trace (merge (connection/summarize connection)
-                                              (capsule/summarize capsule)
-                                              {:type :connection-message})
-                                (i18n/trs "Message '{messageid}' for '{destination}' from '{commonname}' '{remoteaddress}'"))
-                     (->> (determine-next-state broker capsule connection)
-                          (.put (:connections broker) ws))))
-                 (catch map? m
-                   ;; This is a processing error, say an uncaught exception in any of the stuff we meant to do
-                   (send-error-message message (i18n/trs "Error {0} handling message: {1}" (:type m) (:message &throw-context)) connection))))
-              (catch map? m
-                ;; TODO(richardc): this could use a different message_type to
-                ;; indicate an encoding error rather than a processing error
-                (send-error-message nil (i18n/trs "Could not decode message") connection)))))))
+  (time!
+    (:on-message (:metrics broker))
+    (if-not (= :running @(:state broker))
+      (websockets-client/close! ws 1011 (i18n/trs "Broker is not running"))
+      (when-let [connection (process-message! broker bytes ws)]
+        (assert (instance? Connection connection))
+        (.put (:connections broker) ws connection)))))
 
 (defn- on-text!
   "OnMessage (text) websocket event handler"
@@ -502,8 +576,37 @@
   [broker ws bytes offset len]
   (on-message! broker ws bytes))
 
+;;
+;; Other WebSocket event handlers
+;;
+
+(defn- on-connect!
+  "OnMessage WebSocket event handler. Close the WebSocket connection if the
+   Broker service is not running or if the client common name is not obtainalbe
+   from its cert. Otherwise set the idle timeout of the WebSocket connection
+   to 15 min."
+  [broker codec ws]
+  (time!
+    (:on-connect (:metrics broker))
+    (if-not (= :running @(:state broker))
+      (websockets-client/close! ws 1011 (i18n/trs "Broker is not running"))
+      (let [connection (add-connection! broker ws codec)
+            {:keys [common-name]} connection
+            idle-timeout (* 1000 60 15)]
+        (if (nil? common-name)
+          (do
+            (sl/maplog :debug (assoc (connection/summarize connection)
+                                :type :connection-no-peer-certificate)
+                       (i18n/trs "No client certificate, closing '{remoteaddress}'"))
+            (websockets-client/close! ws 4003 (i18n/trs "No client certificate")))
+          (do
+            (websockets-client/idle-timeout! ws idle-timeout)
+            (sl/maplog :debug (assoc (connection/summarize connection)
+                                :type :connection-open)
+                       (i18n/trs "client '{commonname}' connected from '{remoteaddress}'"))))))))
+
 (defn- on-error
-  "OnError websocket event handler"
+  "OnError WebSocket event handler. Just log the event."
   [broker ws e]
   (let [connection (get-connection broker ws)]
     (sl/maplog :error e (assoc (connection/summarize connection)
@@ -511,15 +614,17 @@
                (i18n/trs "Websocket error '{commonname}' '{remoteaddress}'"))))
 
 (defn- on-close!
-  "OnClose websocket event handler"
+  "OnClose WebSocket event handler. Remove the Connection instance out of the
+   broker's 'connections' map."
   [broker ws status-code reason]
   (time! (:on-close (:metrics broker))
          (let [connection (get-connection broker ws)]
-           (sl/maplog :debug (assoc (connection/summarize connection)
-                                    :type :connection-close
-                                    :statuscode status-code
-                                    :reason reason)
-                      (i18n/trs "client '{commonname}' disconnected from '{remoteaddress}' '{statuscode}' '{reason}'"))
+           (sl/maplog
+             :debug (assoc (connection/summarize connection)
+                           :type :connection-close
+                           :statuscode status-code
+                           :reason reason)
+             (i18n/trs "client '{commonname}' disconnected from '{remoteaddress}' '{statuscode}' '{reason}'"))
            (remove-connection! broker ws))))
 
 (s/defn build-websocket-handlers :- {s/Keyword IFn}
@@ -530,7 +635,10 @@
    :on-text    (partial on-text! broker)
    :on-bytes   (partial on-bytes! broker)})
 
-;; service lifecycle
+;;
+;; Broker service lifecycle, codecs, status service
+;;
+
 (def InitOptions
   {:activemq-spool s/Str
    :accept-consumers s/Num
@@ -577,8 +685,6 @@
                               :metrics-registry   (get-metrics-registry)
                               :connections        (ConcurrentHashMap.)
                               :uri-map            (ConcurrentHashMap.)
-                              :transitions        {:open connection-open
-                                                   :associated connection-associated}
                               :broker-cn          (get-broker-cn ssl-cert)
                               :state              (atom :starting)}
           metrics            (build-and-register-metrics broker)
@@ -611,12 +717,8 @@
   [broker :- Broker level :- status-core/ServiceStatusDetailLevel]
   (let [{:keys [state metrics-registry]} broker
         level>= (partial status-core/compare-levels >= level)]
-  {:state @state
-   :status (cond-> {}
-
-             (level>= :info)
-             (assoc :metrics (metrics/get-pcp-metrics metrics-registry))
-
-             (level>= :debug)
-             (assoc :threads (metrics/get-thread-metrics)
-                    :memory (metrics/get-memory-metrics)))}))
+    {:state  @state
+     :status (cond-> {}
+               (level>= :info) (assoc :metrics (metrics/get-pcp-metrics metrics-registry))
+               (level>= :debug) (assoc :threads (metrics/get-thread-metrics)
+                                       :memory (metrics/get-memory-metrics)))}))

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -200,7 +200,7 @@
 
 ;; Session association tests
 
-;; TODO(ale): add more tests
+;; TODO(ale): add more tests (PCP-523)
 
 (defn is-error-message
   "Assert that the message is a PCP error message with the specified description"
@@ -261,7 +261,7 @@
                                                 :version version)]
         ;; NB(ale): client/connect checks associate_response for both clients
         (let [close-websocket-msg1 (client/recv! first-client)]
-          (is (= [4000 "superceded"] close-websocket-msg1)))))))
+          (is (= [4000 "superseded"] close-websocket-msg1)))))))
 
 ;; TODO(ale): change this (PCP-521)
 (deftest second-association-same-connection-should-fail-and-disconnect-test
@@ -608,3 +608,5 @@
 (deftest no-vnext-test
   (with-app-with-config app broker-services no-vnext-config
     (is true)))
+
+(deftest sending-an-invalid-message)

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -608,5 +608,3 @@
 (deftest no-vnext-test
   (with-app-with-config app broker-services no-vnext-config
     (is true)))
-
-(deftest sending-an-invalid-message)

--- a/test/unit/puppetlabs/pcp/broker/capsule_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/capsule_test.clj
@@ -25,10 +25,11 @@
                                                        "pcp://localhost/b"])])
 
 (deftest summarize-test
-  (dotestseq [msg messages]
+  (dotestseq
+    [msg messages]
     (testing "can summarize capsules"
-    (let [capsule (wrap msg)]
-      (is (s/validate CapsuleLog (summarize capsule)))))))
+      (let [capsule (wrap msg)]
+        (is (s/validate CapsuleLog (summarize capsule)))))))
 
 (deftest add-hop-test
   (let [capsule (wrap (message/make-message))]

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -267,9 +267,9 @@
     (is (= nil (reason-to-deny-association broker connection "pcp://test/foo")))
     (is (= "'server' type connections not accepted"
            (reason-to-deny-association broker connection "pcp://test/server")))
-    (is (= "session already associated"
+    (is (= "Session already associated"
            (reason-to-deny-association broker associated "pcp://test/foo")))
-    (is (= "session already associated"
+    (is (= "Session already associated"
            (reason-to-deny-association broker associated "pcp://test/bar")))))
 
 (deftest process-associate-request!-test

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -5,6 +5,7 @@
             [puppetlabs.pcp.broker.capsule :as capsule]
             [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
             [puppetlabs.pcp.message :as message]
+            [puppetlabs.experimental.websockets.client :as websockets-client]
             [schema.core :as s]
             [schema.test :as st]
             [slingshot.test])
@@ -25,7 +26,6 @@
                 :connections        (ConcurrentHashMap.)
                 :metrics-registry   metrics.core/default-registry
                 :metrics            {}
-                :transitions        {}
                 :broker-cn          "broker.example.com"
                 :state              (atom :running)}
         metrics (build-and-register-metrics broker)
@@ -145,89 +145,86 @@
       (is (= "pcp://example01.example.com/foo" (:target (:capsule (first @queued))))))))
 
 (deftest make-ring-request-test
-  (let [broker (make-test-broker)]
-    (testing "it should return a ring request - one target"
-      (let [message (message/make-message :message_type "example1"
-                                          :sender "pcp://example01.example.com/agent"
-                                          :targets ["pcp://example02.example.com/agent"])
-            capsule (capsule/wrap message)]
-        (is (= {:uri "/pcp-broker/send"
-                :request-method :post
-                :remote-addr ""
-                :form-params {}
-                :query-params {"sender" "pcp://example01.example.com/agent"
-                               "targets" "pcp://example02.example.com/agent"
-                               "message_type" "example1"
+  (testing "it should return a ring request - one target"
+    (let [message (message/make-message :message_type "example1"
+                                        :sender "pcp://example01.example.com/agent"
+                                        :targets ["pcp://example02.example.com/agent"])]
+      (is (= {:uri            "/pcp-broker/send"
+              :request-method :post
+              :remote-addr    ""
+              :form-params    {}
+              :query-params   {"sender"             "pcp://example01.example.com/agent"
+                               "targets"            "pcp://example02.example.com/agent"
+                               "message_type"       "example1"
                                "destination_report" false}
-                :params {"sender" "pcp://example01.example.com/agent"
-                         "targets" "pcp://example02.example.com/agent"
-                         "message_type" "example1"
-                         "destination_report" false}}
-               (make-ring-request broker capsule nil)))))
-    (testing "it should return a ring request - two targets"
-      (let [message (message/make-message :message_type "example1"
-                                          :sender "pcp://example01.example.com/agent"
-                                          :targets ["pcp://example02.example.com/agent"
-                                                    "pcp://example03.example.com/agent"])
-            capsule (capsule/wrap message)]
-        (is (= {:uri "/pcp-broker/send"
-                :request-method :post
-                :remote-addr ""
-                :form-params {}
-                :query-params {"sender" "pcp://example01.example.com/agent"
-                               "targets" ["pcp://example02.example.com/agent"
-                                          "pcp://example03.example.com/agent"]
-                               "message_type" "example1"
+              :params         {"sender"             "pcp://example01.example.com/agent"
+                               "targets"            "pcp://example02.example.com/agent"
+                               "message_type"       "example1"
+                               "destination_report" false}}
+             (make-ring-request message nil)))))
+  (testing "it should return a ring request - two targets"
+    (let [message (message/make-message :message_type "example1"
+                                        :sender "pcp://example01.example.com/agent"
+                                        :targets ["pcp://example02.example.com/agent"
+                                                  "pcp://example03.example.com/agent"])]
+      (is (= {:uri            "/pcp-broker/send"
+              :request-method :post
+              :remote-addr    ""
+              :form-params    {}
+              :query-params   {"sender"             "pcp://example01.example.com/agent"
+                               "targets"            ["pcp://example02.example.com/agent"
+                                                     "pcp://example03.example.com/agent"]
+                               "message_type"       "example1"
                                "destination_report" false}
-                :params {"sender" "pcp://example01.example.com/agent"
-                         "targets" ["pcp://example02.example.com/agent"
-                                    "pcp://example03.example.com/agent"]
-                         "message_type" "example1"
-                         "destination_report" false}}
-               (make-ring-request broker capsule nil)))))
-    (testing "it should return a ring request - destination report"
-      (let [message (message/make-message :message_type "example1"
-                                          :sender "pcp://example01.example.com/agent"
-                                          :targets ["pcp://example02.example.com/agent"]
-                                          :destination_report true)
-            capsule (capsule/wrap message)]
-        (is (= {:uri "/pcp-broker/send"
-                :request-method :post
-                :remote-addr ""
-                :form-params {}
-                :query-params {"sender" "pcp://example01.example.com/agent"
-                               "targets" "pcp://example02.example.com/agent"
-                               "message_type" "example1"
+              :params         {"sender"             "pcp://example01.example.com/agent"
+                               "targets"            ["pcp://example02.example.com/agent"
+                                                     "pcp://example03.example.com/agent"]
+                               "message_type"       "example1"
+                               "destination_report" false}}
+             (make-ring-request message nil)))))
+  (testing "it should return a ring request - destination report"
+    (let [message (message/make-message :message_type "example1"
+                                        :sender "pcp://example01.example.com/agent"
+                                        :targets ["pcp://example02.example.com/agent"]
+                                        :destination_report true)]
+      (is (= {:uri            "/pcp-broker/send"
+              :request-method :post
+              :remote-addr    ""
+              :form-params    {}
+              :query-params   {"sender"             "pcp://example01.example.com/agent"
+                               "targets"            "pcp://example02.example.com/agent"
+                               "message_type"       "example1"
                                "destination_report" true}
-                :params {"sender" "pcp://example01.example.com/agent"
-                         "targets" "pcp://example02.example.com/agent"
-                         "message_type" "example1"
-                         "destination_report" true}}
-               (make-ring-request broker capsule nil)))))))
+              :params         {"sender"             "pcp://example01.example.com/agent"
+                               "targets"            "pcp://example02.example.com/agent"
+                               "message_type"       "example1"
+                               "destination_report" true}}
+             (make-ring-request message nil))))))
+
+(defn yes-authorization-check [r] {:authorized true
+                                   :message ""
+                                   :request r})
+
+(defn no-authorization-check [r] {:authorized false
+                                  :message "Danger Zone"
+                                  :request r})
 
 (deftest authorized?-test
-  (let [yes-check (fn [r] {:authorized true
-                           :message ""
-                           :request r})
-        no-check (fn [r] {:authorized false
-                          :message "Danger Zone"
-                          :request r})
-        yes-broker (assoc (make-test-broker) :authorization-check yes-check)
-        no-broker (assoc (make-test-broker) :authorization-check no-check)
+  (let [yes-broker (assoc (make-test-broker) :authorization-check yes-authorization-check)
+        no-broker (assoc (make-test-broker) :authorization-check no-authorization-check)
         message (message/make-message :message_type "example1"
                                       :sender "pcp://example01.example.com/agent"
-                                      :targets ["pcp://example02.example.com/agent"])
-        capsule (capsule/wrap message)]
-    (is (= true (authorized? yes-broker capsule)))
-    (is (= false (authorized? no-broker capsule)))))
+                                      :targets ["pcp://example02.example.com/agent"])]
+    (is (= true (authorized? yes-broker message nil)))
+    (is (= false (authorized? no-broker message nil)))))
 
 (deftest accept-message-for-delivery-test
   (let [broker (make-test-broker)
         capsule (capsule/wrap (message/make-message))
         queued (atom [])]
-    (with-redefs [puppetlabs.pcp.broker.activemq/queue-message (fn [queue capsule] (swap! queued conj {:queue queue
-                                                                                                       :capsule capsule}))
-                  puppetlabs.pcp.broker.core/authorized? (constantly true)]
+    (with-redefs [puppetlabs.pcp.broker.activemq/queue-message (fn [queue capsule]
+                                                                 (swap! queued conj {:queue queue
+                                                                                     :capsule capsule}))]
       (accept-message-for-delivery broker capsule)
       (is (= 1 (count @queued)))
       (is (= accept-queue (:queue (first @queued)))))))
@@ -250,23 +247,18 @@
     (let [message (-> (message/make-message)
                       (assoc :targets ["pcp:///server"]
                              :message_type "http://puppetlabs.com/associate_request"))]
-      (is (= true (session-association-message? message)))))
+      (is (= true (session-association-request? message)))))
   (testing "It returns false when passed a message of an unknown type"
     (let [message (-> (message/make-message)
                       (assoc :targets ["pcp:///server"]
                              ;; OLDJOKE(richardc): we used to call association_request the loginschema
                              :message_type "http://puppetlabs.com/kennylogginsschema"))]
-      (is (= false (session-association-message? message)))))
+      (is (= false (session-association-request? message)))))
   (testing "It returns false when passed a message not aimed to the server target"
     (let [message (-> (message/make-message)
                       (assoc :targets ["pcp://other/server"]
                              :message_type "http://puppetlabs.com/associate_request"))]
-      (is (= false (session-association-message? message))))))
-
-(defn association-capsule
-  [sender seconds]
-  (capsule/wrap (-> (message/make-message :sender sender)
-                    (message/set-expiry seconds :seconds))))
+      (is (= false (session-association-request? message))))))
 
 (deftest reason-to-deny-association-test
   (let [broker     (make-test-broker)
@@ -280,65 +272,80 @@
     (is (= "session already associated"
            (reason-to-deny-association broker associated "pcp://test/bar")))))
 
-(deftest process-associate-message-test
+(deftest process-associate-request!-test
   (let [closed (atom (promise))]
     (with-redefs [puppetlabs.experimental.websockets.client/close! (fn [& args] (deliver @closed args))
-                  puppetlabs.experimental.websockets.client/send! (constantly false)
-                  puppetlabs.pcp.broker.core/authorized? (constantly true)]
+                  puppetlabs.experimental.websockets.client/send! (constantly false)]
       (let [message (-> (message/make-message :sender "pcp://localhost/controller"
                                               :message_type "http://puppetlabs.com/login_message")
                         (message/set-expiry 3 :seconds))
             capsule (capsule/wrap message)]
-        (testing "It should return an associated session"
+        (testing "It should return an associated Connection if there's no reason to deny association"
           (reset! closed (promise))
           (let [broker     (make-test-broker)
                 connection (add-connection! broker "ws" identity-codec)
-                connection (process-associate-message broker capsule connection)]
+                connection (process-associate-request! broker capsule connection)]
             (is (not (realized? @closed)))
             (is (= :associated (:state connection)))
             (is (= "pcp://localhost/controller" (:uri connection)))))
-
-        (testing "It allows a login to from two locations for the same uri, but disconnects the first"
+        (testing "Associates a client already associated on a different session, but disconnects the first"
           (reset! closed (promise))
           (let [broker (make-test-broker)
                 connection1 (add-connection! broker "ws1" identity-codec)
                 connection2 (add-connection! broker "ws2" identity-codec)]
-            (process-associate-message broker capsule connection1)
-            (is (process-associate-message broker capsule connection2))
+            (process-associate-request! broker capsule connection1)
+            (is (process-associate-request! broker capsule connection2))
             (is (= ["ws1" 4000 "superceded"] @@closed))
             (is (= ["ws2"] (keys (:connections broker))))))
-
-        (testing "It does not allow a login to happen twice on the same websocket"
+        ;; TODO(ale): change this behaviour (PCP-521)
+        (testing "No association for the same WebSocket session; closes and returns nil"
           (reset! closed (promise))
           (let [broker (make-test-broker)
                 connection (add-connection! broker "ws" identity-codec)
-                connection (process-associate-message broker capsule connection)
-                connection (process-associate-message broker capsule connection)]
+                connection (process-associate-request! broker capsule connection)
+                outcome1 (process-associate-request! broker capsule connection)
+                outcome2 (process-associate-request! broker capsule connection)]
+            ;; NB(ale): in this case, the Connection object is removed from the
+            ;; broker's connections map by the onClose handler once triggered
             (is (= :associated (:state connection)))
+            (is (nil? outcome1))
+            (is (nil? outcome2))
+            (is (= ["ws" 4002 "association unsuccessful"] @@closed))))
+        (testing "No association if a reason to deny is provided; closes the session and return nil"
+          (reset! closed (promise))
+          (let [broker (make-test-broker)
+                connection (add-connection! broker "ws" identity-codec)
+                outcome (process-associate-request! broker capsule connection "because I said so!")]
+            ;; NB(ale): as above, the connections map is updated after onClose
+            (is (nil? outcome))
             (is (= ["ws" 4002 "association unsuccessful"] @@closed))))))))
 
-(deftest process-inventory-message-test
+(deftest process-inventory-request-test
   (let [broker (make-test-broker)
         message (-> (message/make-message :sender "pcp://test.example.com/test")
                     (message/set-json-data  {:query ["pcp://*/*"]}))
         capsule (capsule/wrap message)
         connection (connection/make-connection "ws1" identity-codec)
+        connection (assoc connection :state :associated)
         accepted (atom nil)]
-    (with-redefs [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule] (reset! accepted capsule))
-                  puppetlabs.pcp.broker.core/authorized? (constantly true)]
-      (process-inventory-message broker capsule connection)
-      (is (= [] (:uris (message/get-json-data (:message @accepted))))))))
+    (with-redefs
+      [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule]
+                                                                (reset! accepted capsule))]
+      (let [outcome (process-inventory-request broker capsule connection)]
+        (is (nil? outcome))
+        (is (= [] (:uris (message/get-json-data (:message @accepted)))))))))
 
-(deftest process-server-message-test
+(deftest process-server-message!-test
   (let [broker (make-test-broker)
         message (message/make-message :message_type "http://puppetlabs.com/associate_request")
         capsule (capsule/wrap message)
         connection (connection/make-connection "ws1" identity-codec)
         associate-request (atom nil)]
-    (with-redefs [puppetlabs.pcp.broker.core/process-associate-message (fn [broker capsule connection]
-                                                                         (reset! associate-request capsule)
-                                                                         connection)]
-      (process-server-message broker capsule connection)
+    (with-redefs
+      [puppetlabs.pcp.broker.core/process-associate-request! (fn [broker capsule connection]
+                                                               (reset! associate-request capsule)
+                                                               connection)]
+      (process-server-message! broker capsule connection)
       (is (not= nil @associate-request)))))
 
 (s/defn dummy-connection-from :- Connection
@@ -346,57 +353,106 @@
   (assoc (connection/make-connection "ws1" identity-codec)
          :common-name common-name))
 
-(deftest check-sender-matches-test
+(deftest authenticated?-test
   (testing "simple match"
-    (is (check-sender-matches (message/make-message :sender "pcp://lolcathost/agent")
-                              (dummy-connection-from "lolcathost"))))
+    (is (authenticated? (message/make-message :sender "pcp://lolcathost/agent")
+                        (dummy-connection-from "lolcathost"))))
   (testing "simple mismatch"
-    (is (not (check-sender-matches (message/make-message :sender "pcp://lolcathost/agent")
-                                   (dummy-connection-from "remotecat")))))
+    (is (not (authenticated? (message/make-message :sender "pcp://lolcathost/agent")
+                             (dummy-connection-from "remotecat")))))
   (testing "accidental regex collisions"
-    (is (not (check-sender-matches (message/make-message :sender "pcp://lolcathost/agent")
-                                   (dummy-connection-from "lol.athost"))))))
+    (is (not (authenticated? (message/make-message :sender "pcp://lolcathost/agent")
+                             (dummy-connection-from "lol.athost"))))))
 
-(deftest connection-open-test
-  (let [broker (make-test-broker)
-        message (message/make-message :targets ["pcp:///server"]
+(defn make-valid-ring-request
+  [message _]
+  (let [{:keys [sender targets message_type destination_report]} message
+        params {"sender"             sender
+                "targets"            targets
+                "message_type"       message_type
+                "destination_report" destination_report}]
+    {:uri            "/pcp-broker/send"
+     :request-method :post
+     :remote-addr    ""
+     :form-params    {}
+     :query-params   params
+     :params         params}))
+
+(deftest validate-message-test
+  (testing "ignores messages other than associate_request if connection not associated"
+    (let [broker (make-test-broker)
+          capsule (capsule/wrap (message/make-message))
+          connection (dummy-connection-from "localpost")
+          is-association-request false]
+      (is (= :to-be-ignored-during-association
+             (validate-message broker capsule connection is-association-request)))))
+  (testing "correctly marks not authenticated messages"
+    (let [broker (make-test-broker)
+          msg (message/make-message :sender "pcp://localpost/office"
+                                    :message_type "http://puppetlabs.com/associate_request")
+          capsule (capsule/wrap msg)
+          connection (dummy-connection-from "groceryshop")
+          is-association-request true]
+      (is (= :not-authenticated
+             (validate-message broker capsule connection is-association-request)))))
+  (with-redefs [puppetlabs.pcp.broker.core/make-ring-request make-valid-ring-request]
+    (testing "correctly marks not authorized messages"
+      (let [no-broker (assoc (make-test-broker) :authorization-check no-authorization-check)
+            msg (message/make-message :sender "pcp://greyhacker/exploit"
                                       :message_type "http://puppetlabs.com/associate_request")
-        capsule (capsule/wrap message)
-        connection (connection/make-connection "ws1" identity-codec)
-        associate-request (atom nil)]
-    (with-redefs [puppetlabs.pcp.broker.core/process-associate-message (fn [broker capsule connection]
-                                                                         (reset! associate-request capsule)
-                                                                         connection)]
-      (connection-open broker capsule connection)
-      (is (not= nil @associate-request)))))
+            capsule (capsule/wrap msg)
+            connection (dummy-connection-from "greyhacker")
+            is-association-request true]
+        (is (= :not-authorized
+               (validate-message no-broker capsule connection is-association-request)))))
+    (testing "correctly marks expired messages"
+      (let [yes-broker (assoc (make-test-broker) :authorization-check yes-authorization-check)
+            msg (message/make-message :sender "pcp://localcost/gbp"
+                                      :message_type "http://puppetlabs.com/associate_request")
+            capsule (capsule/wrap (message/set-expiry msg -3 :seconds))
+            connection (dummy-connection-from "localcost")
+            is-association-request true]
+        (is (= :expired
+               (validate-message yes-broker capsule connection is-association-request)))))
+    (testing "correctly marks messages to be processed"
+      (let [yes-broker (assoc (make-test-broker) :authorization-check yes-authorization-check)
+            msg (message/make-message :sender "pcp://localghost/opera"
+                                      :message_type "http://puppetlabs.com/associate_request")
+            capsule (capsule/wrap (message/set-expiry msg 5 :seconds))
+            connection (dummy-connection-from "localghost")
+            is-association-request true]
+        (is (= :to-be-processed
+               (validate-message yes-broker capsule connection is-association-request)))))))
 
-(deftest connection-associated-test
-  (let [broker (make-test-broker)
-        message (-> (message/make-message :message_type "http://puppetlabs.com/associate_request")
-                    (message/set-expiry 3 :seconds))
-        capsule (capsule/wrap message)
-        connection (connection/make-connection "ws1" identity-codec)
-        accepted (atom nil)]
-    (with-redefs [puppetlabs.pcp.broker.core/accept-message-for-delivery (fn [broker capsule]
-                                                                           (reset! accepted capsule))]
-      (connection-associated broker capsule connection)
-      (is (not= nil @accepted)))))
-
-(deftest determine-next-state-test
-  (testing "illegal next states raise due to schema validation"
-    (let [broker (make-test-broker)
-          broker (assoc broker :transitions {:open (fn [_ _ c] (assoc c :state :badbadbad))})
-          connection (connection/make-connection "ws" identity-codec)
-          message (message/make-message)
-          capsule (capsule/wrap message)]
-      (is (= :open (:state connection)))
-      (is (thrown+? [:type :schema.core/error]
-                    (determine-next-state broker capsule connection)))))
-  (testing "legal next states are accepted"
-    (let [broker (make-test-broker)
-          broker (assoc broker :transitions {:open (fn [_ _ c] (assoc c :state :associated))})
-          connection (connection/make-connection "ws" identity-codec)
-          message (message/make-message)
-          capsule (capsule/wrap message)
-          next (determine-next-state broker capsule connection)]
-      (is (= :associated (:state next))))))
+;; TODO(ale): add more tests for onMessage processing
+(deftest process-message!-test
+  (let [broker (assoc (make-test-broker) :authorization-check yes-authorization-check)]
+    (with-redefs [puppetlabs.pcp.broker.core/make-ring-request make-valid-ring-request]
+      (testing "sends an error message and returns nil, in case it fails to deserialize"
+        (let [error-message-description (atom nil)]
+          (with-redefs [puppetlabs.pcp.broker.core/get-connection
+                         (fn [broker ws] (add-connection! broker "ws" identity-codec))
+                        puppetlabs.pcp.broker.core/send-error-message
+                          (fn [msg description connection] (reset! error-message-description description) nil)]
+            (let [outcome (process-message! broker (byte-array [42]) nil)]
+              (is (= "Could not decode message" @error-message-description))
+              (is (nil? outcome))))))
+      (testing "queues a ttl_expired in case of expired msg (not associate_session)"
+        (let [called-process-expired (atom false)
+              msg (message/make-message :sender "pcp://host_a/entity"
+                                        :message_type "some_kinda_love"
+                                        :targets ["pcp://host_b/entity"])
+              capsule (capsule/wrap (message/set-expiry msg 5 :seconds))
+              raw-msg (->> capsule (capsule/encode) (message/encode))
+              connection (merge (dummy-connection-from "host_a")
+                                {:state :associated
+                                 :codec {:decode (fn [bytes] msg)
+                                         :encode (fn [msg] raw-msg)}})]
+          (.put (:connections broker) "ws1" connection)
+          (with-redefs [puppetlabs.pcp.broker.core/get-connection
+                          (fn [broker ws] connection)
+                        puppetlabs.pcp.broker.core/process-expired-message
+                          (fn [broker capsule] (reset! called-process-expired true))]
+            (let [outcome (process-message! broker raw-msg nil)]
+              (is @called-process-expired)
+              (is (nil? outcome)))))))))

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.pcp.testutils.client
   (:require [clojure.test :refer :all]
-            [clojure.core.async :as async :refer [timeout alts!! chan >!! <!!]]
+            [clojure.core.async :as async :refer [timeout alts!! chan >!! <!! put!]]
             [http.async.client :as http]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.pcp.message :as message]
@@ -60,9 +60,9 @@
                                             :open  (fn [ws]
                                                      (http/send ws :byte (message/encode association-request)))
                                             :byte  (fn [ws msg]
-                                                     (>!! message-chan (message/decode msg)))
+                                                     (put! message-chan (message/decode msg)))
                                             :close (fn [ws code reason]
-                                                     (>!! message-chan [code reason])))
+                                                     (put! message-chan [code reason])))
         wrapper             (ChanClient. client ws message-chan)]
     (if check-association
       (let [response (recv! wrapper)]


### PR DESCRIPTION
Still WORK IN PROGRESS as:
 - [x] I must update the integration tests;-
 - [x] I may add new tests to core_test (PCP-523);
 - [ ] there are a number of TODOs to be resolved;
 - [ ] I will try to factor out PCP-385 changes and split the commit in
   different pieces.

Checking the validity of incoming messages only once, meaning:
 - ignore messages other than associate_request before Association is
   complete;
 - authentication;
 - authorization;
 - TTL check.

Removing the transitions map that keept track of the state of the
association during the message double dispatch mechanism in favour of
making explicit the processing workflow.

Avoiding to update the 'connections' map for each processing message. In
practice, the onMessage handler will update the map only if the
Connection instance being processed is actually updated; that happens
only in case of a successful associate_request.

In case of invalid (as above) associate_request, an unsuccessful
associate_response is sent back to the requester and the WebSocket
connection is closed. That's a behaviour change, as:
 - in case of authentication failure, the broker used to send a PCP
   error and close the WebSocket;
 - in case of authorization failure, the broker used to only close the
   WebSocket.