### PR TITLE
(PCP-526) Don't do schema validation in tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ lein: lein2
 jdk:
   - oraclejdk7
   - openjdk7
-script: lein2 test
+script: lein2 with-profile test:test-schema-validation test
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -102,6 +102,10 @@
                                   ;; Transitive dependency for lein-cloverage and puppetlabs/kitchensink
                                   [org.clojure/tools.cli "0.3.0"]]
                    :plugins [[lein-cloverage "1.0.6" :excludes [org.clojure/clojure org.clojure/tools.cli]]]}
+             :dev-schema-validation [:dev
+                                     {:injections [(do
+                                                    (require 'schema.core)
+                                                    (schema.core/set-fn-validation! true))]}]
              :unit {:source-paths ["test/utils" "test-resources"]
                     :dependencies [[http.async.client ~http-async-client-version :exclusions [org.clojure/clojure]]]
                     :test-paths ^:replace ["test/unit"]}
@@ -109,6 +113,10 @@
                            {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
                                            [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]
                             :test-paths ^:replace ["test/integration"]}]
+             :test-schema-validation [:test
+                                      {:injections [(do
+                                                     (require 'schema.core)
+                                                     (schema.core/set-fn-validation! true))]}]
              :cljfmt {:plugins [[lein-cljfmt "0.3.0"]
                                 [lein-parent "0.2.1"]]
                       :parent-project {:path "../pl-clojure-style/project.clj"

--- a/project.clj
+++ b/project.clj
@@ -106,17 +106,19 @@
                                      {:injections [(do
                                                     (require 'schema.core)
                                                     (schema.core/set-fn-validation! true))]}]
-             :unit {:source-paths ["test/utils" "test-resources"]
-                    :dependencies [[http.async.client ~http-async-client-version :exclusions [org.clojure/clojure]]]
-                    :test-paths ^:replace ["test/unit"]}
-             :integration [:unit
-                           {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
-                                           [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]
-                            :test-paths ^:replace ["test/integration"]}]
+             :test {:source-paths ["test/utils" "test-resources"]
+                    :dependencies [[http.async.client ~http-async-client-version :exclusions [org.clojure/clojure]]
+                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]
+                    :test-paths ^:replace ["test/unit" "test/integration"]}
              :test-schema-validation [:test
                                       {:injections [(do
                                                      (require 'schema.core)
                                                      (schema.core/set-fn-validation! true))]}]
+             :unit [:test
+                    {:test-paths ^:replace ["test/unit"]}]
+             :integration [:test
+                           {:test-paths ^:replace ["test/integration"]}]
              :cljfmt {:plugins [[lein-cljfmt "0.3.0"]
                                 [lein-parent "0.2.1"]]
                       :parent-project {:path "../pl-clojure-style/project.clj"

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -65,7 +65,6 @@
   (fs/delete-dir (get-in broker-config [:pcp-broker :broker-spool]))
   (f))
 
-(use-fixtures :once st/validate-schemas)
 ; increase ttl set by the `puppetlabs.pcp.message/set-expiry` function
 ; 5 times to prevent test failures caused by the expiration of the ttl
 ; on messages exchanged during the tests;
@@ -80,6 +79,7 @@
                                                            ([message timestamp]
                                                             (message-set-expiry message timestamp)))]
                           (fn-test)))))
+
 (use-fixtures :each cleanup-spool-fixture)
 
 (deftest it-talks-websockets-test

--- a/test/unit/puppetlabs/pcp/broker/activemq_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/activemq_test.clj
@@ -3,6 +3,4 @@
             [puppetlabs.pcp.broker.activemq :refer :all]
             [schema.test :as st]))
 
-(use-fixtures :once st/validate-schemas)
-
 ;; We're just here to catch simple typos

--- a/test/unit/puppetlabs/pcp/broker/capsule_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/capsule_test.clj
@@ -8,8 +8,6 @@
             [slingshot.test])
   (:import [puppetlabs.pcp.broker.capsule Capsule]))
 
-(use-fixtures :once st/validate-schemas)
-
 (deftest wrap-message-test
   (testing "wrapping a Message in a capsule"
     (is (instance? Capsule (wrap (message/make-message)))))

--- a/test/unit/puppetlabs/pcp/broker/capsule_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/capsule_test.clj
@@ -11,8 +11,6 @@
 (deftest wrap-message-test
   (testing "wrapping a Message in a capsule"
     (is (instance? Capsule (wrap (message/make-message)))))
-  (testing "fails if an invalid message is given"
-    (is (thrown? Exception (wrap {:things "bad stuff"}))))
   (testing "does not add any debug hop entry"
     (is (empty? (:hops (wrap (message/make-message)))))))
 

--- a/test/unit/puppetlabs/pcp/broker/connection_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/connection_test.clj
@@ -7,8 +7,6 @@
   {:encode identity
    :decode identity})
 
-(use-fixtures :once st/validate-schemas)
-
 (deftest make-connection-test
   (testing "It returns a map that matches represents a new socket"
     (let [socket (make-connection "ws" identity-codec)]

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -406,15 +406,6 @@
       (is (not= nil @accepted)))))
 
 (deftest determine-next-state-test
-  (testing "illegal next states raise due to schema validation"
-    (let [broker (make-test-broker)
-          broker (assoc broker :transitions {:open (fn [_ _ c] (assoc c :state :badbadbad))})
-          connection (connection/make-connection "ws" identity-codec)
-          message (message/make-message)
-          capsule (capsule/wrap message)]
-      (is (= :open (:state connection)))
-      (is (thrown+? [:type :schema.core/error]
-                    (determine-next-state broker capsule connection)))))
   (testing "legal next states are accepted"
     (let [broker (make-test-broker)
           broker (assoc broker :transitions {:open (fn [_ _ c] (assoc c :state :associated))})

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -36,7 +36,30 @@
   {:encode identity
    :decode identity})
 
-(use-fixtures :once st/validate-schemas)
+
+
+
+
+
+
+; TODO(ale): THIS MUST PASS, THEN REMOVE IT
+
+
+(deftest bad-message-check
+  (testing "This should fail only with schema validation ON"
+    (let [msg {:title "dying for it"
+               :targets "bull"
+               :message_type 123}]
+      (is (not (session-association-message? msg))))))
+
+
+
+
+
+
+
+
+
 
 (deftest get-broker-cn-test
   (testing "It returns the correct cn"

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -36,31 +36,6 @@
   {:encode identity
    :decode identity})
 
-
-
-
-
-
-
-; TODO(ale): THIS MUST PASS, THEN REMOVE IT
-
-
-(deftest bad-message-check
-  (testing "This should fail only with schema validation ON"
-    (let [msg {:title "dying for it"
-               :targets "bull"
-               :message_type 123}]
-      (is (not (session-association-message? msg))))))
-
-
-
-
-
-
-
-
-
-
 (deftest get-broker-cn-test
   (testing "It returns the correct cn"
     (let [cn (get-broker-cn "./test-resources/ssl/certs/broker.example.com.pem")]

--- a/test/unit/puppetlabs/pcp/broker/in_memory_inventory_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/in_memory_inventory_test.clj
@@ -3,8 +3,6 @@
             [puppetlabs.pcp.broker.in-memory-inventory :refer :all]
             [schema.test :as st]))
 
-(use-fixtures :once st/validate-schemas)
-
 (deftest endpoint-pattern-match?-test
   (testing "direct matches"
     (is (endpoint-pattern-match? "pcp://pies/agent" "pcp://pies/agent"))


### PR DESCRIPTION
Adding new profiles that extend, respectively, the dev and test
profiles by using an :injection entry to enable schema validation
via (schema.core/set-fn-validation! true).

Removing the (schema.core/set-fn-validation! true) calls in the test
source files as we now rely on the test-schema-validation lein profile
to enable schema validation.