### PR TITLE
(PCP-525) Rely on pcp-common.message for validating Messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,7 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/pcp-common "0.5.1"]
+                 [puppetlabs/pcp-common "0.5.2"]
 
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4"]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -602,7 +602,7 @@
 ;;
 
 (defn- on-connect!
-  "OnMessage WebSocket event handler. Close the WebSocket connection if the
+  "OnOpen WebSocket event handler. Close the WebSocket connection if the
    Broker service is not running or if the client common name is not obtainalbe
    from its cert. Otherwise set the idle timeout of the WebSocket connection
    to 15 min."

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -504,8 +504,6 @@
         decode (get-in connection [:codec :decode])]
     (try+
       (let [message (decode bytes)
-            ;; TODO(ale): consider moving the validation to pcp-common (PCP-525)
-            message (s/validate Message message)
             capsule (capsule/wrap message)
             message-data (merge (connection/summarize connection)
                                 (capsule/summarize capsule))

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -470,7 +470,7 @@
       (let [broker (assoc (make-test-broker) :authorization-check yes-authorization-check)
             error-message-description (atom nil)]
         (with-redefs [puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] (add-connection! broker "ws" identity-codec))
+                      (fn [broker ws] (add-connection! broker "ws" v1-codec))
                       puppetlabs.pcp.broker.core/send-error-message
                       (fn [msg description connection] (reset! error-message-description description) nil)]
           (let [outcome (process-message! broker (byte-array [42]) nil)]

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.pcp.broker.core-test
   (:require [clojure.test :refer :all]
             [metrics.core]
+            [puppetlabs.pcp.testutils :refer [dotestseq]]
             [puppetlabs.pcp.broker.core :refer :all]
             [puppetlabs.pcp.broker.capsule :as capsule]
             [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
@@ -473,9 +474,19 @@
                       (fn [broker ws] (add-connection! broker "ws" v1-codec))
                       puppetlabs.pcp.broker.core/send-error-message
                       (fn [msg description connection] (reset! error-message-description description) nil)]
-          (let [outcome (process-message! broker (byte-array [42]) nil)]
-            (is (= "Could not decode message" @error-message-description))
-            (is (nil? outcome))))))
+          (dotestseq
+            [raw-message [(byte-array [])           ; empty message
+                          (byte-array [0])          ; bad message
+                          (byte-array [3 3 3 3 3])  ; bad message
+                          (byte-array [1,           ; first chunk not envelope
+                                       2, 0 0 0 2, 123 125])
+                          (byte-array [1,           ; bad envelope
+                                       1, 0 0 0 1, 12 12 12 12])
+                          (byte-array [1,           ; bad (incomplete) envelope
+                                       1, 0 0 0 2, 123])]]
+            (let [outcome (process-message! broker (byte-array raw-message) nil)]
+              (is (= "Could not decode message" @error-message-description))
+                       (is (nil? outcome)))))))
     (testing "queues message for delivery in case of expired msg (not associate_session)"
       (let [broker (assoc (make-test-broker)
                           :authorization-check yes-authorization-check


### PR DESCRIPTION
- bumping to clj-pcp-common 0.5.2
- fixing process-message! test
- removing s/validate call for decoded messages in process-message!
- adding more unit tests for process-messasge!