### PR TITLE
(maint) Minor cleanup for puppet-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pom.xml.asc
 *~
 /.idea
 /test-resources/tmp/
+/test-resources/log/pcp-broker-messages.log
 /resources/locales.clj
 /eng-resources
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def tk-version "1.4.0")
+(def tk-version "1.5.0")
 (def ks-version "1.3.0")
 (def i18n-version "0.4.3")
 (def http-async-client-version "0.6.1")
@@ -21,12 +21,7 @@
                  ;;   puppetlabs/trapperkeeper-metrics
                  ;;   puppetlabs/structured-logging
                  ;;   org.slf4j/jcl-over-slf4
-                 [org.slf4j/slf4j-api "1.7.12"]
-
-                 ;; Transitive dependency for:
-                 ;;   ch.qos.logback/logback-classic via puppetlabs/trapperkeeper
-                 ;;   net.logstash.logback/logstash-logback-encoder via puppetlabs/structured-logging
-                 [ch.qos.logback/logback-core "1.1.3"]
+                 [org.slf4j/slf4j-api "1.7.20"]
 
                  ;; Transitive dependency for puppetlabs/trapperkeeper-authorization, and a direct dependency
                  [clj-time "0.10.0"]
@@ -44,7 +39,7 @@
                  [puppetlabs/trapperkeeper-authorization "0.1.5"]
                  [puppetlabs/trapperkeeper-metrics "0.1.1"]
                  ;; Exclude clojure dep for now as that will force a ripple up to clojure 1.7.0
-                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.7" :exclusions [org.clojure/clojure]]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.10" :exclusions [org.clojure/clojure]]
                  [puppetlabs/trapperkeeper-status "0.2.1"]
 
                  ;; Exclude clojure dep for now as that will force a ripple up to clojure 1.7.0
@@ -52,14 +47,8 @@
 
                  [cheshire "5.5.0"]
 
-                 ;; Transitive dependency for:
-                 ;;   nippy
-                 ;;   org.clojure/tools.analyzer.jvm via org.clojure/core.async via puppetlabs/trapperkeeper
-                 [org.clojure/tools.reader "1.0.0-alpha1"]
-
                  [com.taoensso/nippy "2.9.0"]
 
-                 [org.clojure/java.jmx "0.3.0"]
                  [metrics-clojure "2.5.1"]
 
                  ;; try+/throw+

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -38,7 +38,8 @@
    :connections        ConcurrentHashMap ;; Mapping of Websocket session to Connection state
    :metrics-registry   Object
    :metrics            {s/Keyword Object}
-   :broker-cn          s/Str
+   :ssl-cert           s/Str
+   :broker-cn          Atom
    :state              Atom})
 
 (s/defn build-and-register-metrics :- {s/Keyword Object}
@@ -704,7 +705,8 @@
                               :metrics-registry   (get-metrics-registry)
                               :connections        (ConcurrentHashMap.)
                               :uri-map            (ConcurrentHashMap.)
-                              :broker-cn          (get-broker-cn ssl-cert)
+                              :ssl-cert           ssl-cert
+                              :broker-cn          (atom "")
                               :state              (atom :starting)}
           metrics            (build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
@@ -719,7 +721,8 @@
 
 (s/defn start
   [broker :- Broker]
-  (let [{:keys [activemq-broker state]} broker]
+  (let [{:keys [activemq-broker ssl-cert broker-cn state]} broker]
+    (reset! broker-cn (get-broker-cn ssl-cert))
     (mq/start-broker! activemq-broker)
     (subscribe-to-queues! broker)
     (reset! state :running)))


### PR DESCRIPTION
Bumps project dependencies and delays reading the broker certificate until service starts so it can be run in a puppet-server JVM. Also ignore the pcp access log.
