### PR TITLE
(maint) Add access log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pom.xml.asc
 *~
 /.idea
 /test-resources/tmp/
+/test-resources/log/pcp-broker-messages.log
 /resources/locales.clj
 /eng-resources
 


### PR DESCRIPTION
Add the access log location configured for dev/test to .gitignore.
