### PR TITLE
(maint) Use profile for enabling schema checks

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,12 +1,9 @@
 (ns user
   (:require [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
             [puppetlabs.trapperkeeper.config :as tk-config]
-            [puppetlabs.trapperkeeper.main :as tk-main]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tk-app]
-            [clojure.tools.namespace.repl :as repl]
-            [clojure.tools.logging :as log]
-            [schema.core :as s]))
+            [clojure.tools.namespace.repl :as repl]))
 
 ;; NOTE: in some other projects, where we need to support per-developer config
 ;;  variations, we'll put this code into a namespace called 'user-repl', and
@@ -35,13 +32,6 @@
 (defn go []
   (init)
   (start))
-
-(defn -main
-  "Run trapperkeeper with schema validations enabled"
-  [& args]
-  (s/with-fn-validation
-    (log/info "Running trapperkeeper with schema validations enabled.")
-    (apply tk-main/-main args)))
 
 (defn reset []
   (stop)

--- a/project.clj
+++ b/project.clj
@@ -110,7 +110,7 @@
 
   :aliases {"tk" ["trampoline" "run" "--config" "test-resources/conf.d"]
             ;; runs trapperkeeper with schema validations enabled
-            "tkv" ["trampoline" "run" "-m" "user" "--config" "test-resources/conf.d"]
+            "tkv" ["with-profile" "dev-schema-validation" "tk"]
             "certs" ["trampoline" "run" "-m" "puppetlabs.pcp.testutils.certs" "--config" "test-resources/conf.d" "--"]
             ;; cljfmt requires pl-clojure-style's root dir as per above profile;
             ;; run with 'check' then 'fix' with args (refer to the project docs)


### PR DESCRIPTION
Previously a dedicated function was used for enabling of the schema checks.
Since we now have a profile for the same purpose, let's use it instead and drop the function.