### PR TITLE
(maint) Update to clj-parent 0.2.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.1.7"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.2.4"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -22,7 +22,7 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
-                 [puppetlabs/trapperkeeper-metrics "0.1.1"]
+                 [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-webserver-jetty9]
                  [puppetlabs/trapperkeeper-status]
 

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -4,4 +4,5 @@ puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-servi
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -10,6 +10,7 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :refer [metrics-service]]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
             [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service]]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
@@ -53,7 +54,7 @@
 
 (def broker-services
   "The trapperkeeper services the broker needs"
-  [authorization-service broker-service jetty9-service webrouting-service metrics-service status-service])
+  [authorization-service broker-service jetty9-service webrouting-service metrics-service status-service scheduler-service])
 
 (deftest it-talks-websockets-test
   (with-app-with-config app broker-services broker-config


### PR DESCRIPTION
This pins a version of tk-metrics so that orchestrator and pcp-broker
will be compatible without requiring an override.