### PR TITLE
(maint) Bump pcp-common to 0.5.5 and prepare 0.8.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.5
+
+This is a maintenance release to bump clj-pcp-common to 0.5.5.
+
 ## 0.8.4
 
 This is a maintenance release to publish 0.8.2 to clojars.

--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,7 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/pcp-common "0.5.4"]
+                 [puppetlabs/pcp-common "0.5.5"]
 
                  ;; MQ - activemq
                  [clamq/clamq-activemq "0.4"]


### PR DESCRIPTION
Incorporates PCP-620 fix into pcp-broker.