### PR TITLE
(PCP-600) Inventory updates

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -18,26 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "Sending PCP message to '{uri}': '{rawmsg}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Error in deliver-message"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "not connected"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Received session association for '{uri}' from '{commonname}' "
 "'{remoteaddress}'. Session was already associated as '{existinguri}'"
@@ -173,4 +153,28 @@ msgstr ""
 
 #: src/puppetlabs/pcp/broker/service.clj
 msgid "Broker service <'{brokername}'> stopped"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Sending PCP message to '{uri}': '{rawmsg}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Error in deliver-message"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "not connected"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "client no longer connected"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-common "1.0.0"]
+                 [puppetlabs/pcp-common "1.1.0"]
 
                  [puppetlabs/i18n]]
 

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.pcp.broker.core
-  (:require [metrics.gauges :as gauges]
-            [puppetlabs.experimental.websockets.client :as websockets-client]
+  (:require [puppetlabs.experimental.websockets.client :as websockets-client]
+            [puppetlabs.pcp.broker.shared :as shared :refer
+             [Broker get-connection summarize send-error-message send-message deliver-message deliver-server-message]]
             [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
             [puppetlabs.pcp.broker.websocket :refer [Websocket ws->uri ws->client-type]]
             [puppetlabs.pcp.broker.metrics :as metrics]
@@ -19,28 +20,10 @@
             [slingshot.slingshot :refer [throw+ try+]]
             [puppetlabs.i18n.core :as i18n])
   (:import [puppetlabs.pcp.broker.connection Connection]
-           [clojure.lang IFn Atom]
+           [clojure.lang IFn]
            [java.util.concurrent ConcurrentHashMap]
            [java.net InetAddress UnknownHostException]
            [java.security KeyStore]))
-
-(def Broker
-  {:broker-name         (s/maybe s/Str)
-   :authorization-check IFn
-   :inventory           ConcurrentHashMap ;; Mapping of Uri to Connection
-   :metrics-registry    Object
-   :metrics             {s/Keyword Object}
-   :state               Atom})
-
-(s/defn build-and-register-metrics :- {s/Keyword Object}
-  [broker :- Broker]
-  (let [registry (:metrics-registry broker)]
-    (gauges/gauge-fn registry ["puppetlabs.pcp.connections"]
-                     (fn [] (count (:inventory broker))))
-    {:on-connect       (.timer registry "puppetlabs.pcp.on-connect")
-     :on-close         (.timer registry "puppetlabs.pcp.on-close")
-     :on-message       (.timer registry "puppetlabs.pcp.on-message")
-     :on-send          (.timer registry "puppetlabs.pcp.on-send")}))
 
 (defn get-certificate-chain
   "Return the first non-empty certificate chain encountered while scanning the
@@ -84,97 +67,28 @@
 
 ;; connection map lifecycle
 (s/defn add-connection! :- Connection
-  "Add a Connection to the 'inventory' to track a websocket"
+  "Add a Connection to the 'routing-map' to track the websocket and register
+  the change to update 'inventory' when appropriate"
   [broker :- Broker
    connection :- Connection]
   (let [uri (ws->uri (:websocket connection))]
-    (.put (:inventory broker) uri connection)
+    (-> (shared/get-routing-map broker)
+        (.put uri connection))
+    (inventory/add-client broker uri)
     connection))
 
 (s/defn remove-connection!
-  "Remove tracking of a Connection from the broker by websocket"
+  "Remove a Connection from the 'routing-map' and register the change to
+  update 'inventory' when appropriate"
   [broker :- Broker
    uri :- p/Uri]
-  (.remove (:inventory broker) uri))
-
-(s/defn get-connection :- (s/maybe Connection)
-  [broker :- Broker
-   uri :- p/Uri]
-  (get (:inventory broker) uri))
+  (-> (shared/get-routing-map broker)
+      (.remove uri))
+  (inventory/remove-client broker uri))
 
 ;;
 ;; Message processing
 ;;
-
-(def MessageLog
-  "Schema for a loggable summary of a message"
-  {:messageid p/MessageId
-   :source s/Str
-   :messagetype s/Str
-   :destination p/Uri})
-
-(s/defn summarize :- MessageLog
-  [message :- Message]
-  {:messageid (:id message)
-   :messagetype (:message_type message)
-   :source (:sender message)
-   :destination (:target message)})
-
-;; message lifecycle
-
-(s/defn send-message
-  [connection :- Connection
-   message :- Message]
-  (sl/maplog :trace {:type :outgoing-message-trace
-                     :uri (ws->uri (:websocket connection))
-                     :rawmsg message}
-             (i18n/trs "Sending PCP message to '{uri}': '{rawmsg}'"))
-  (websockets-client/send! (:websocket connection)
-                           ((get-in connection [:codec :encode]) message))
-  nil)
-
-(s/defn send-error-message
-  [in-reply-to-message :- (s/maybe Message)
-   description :- s/Str
-   connection :- Connection]
-  (let [error-msg (cond-> (message/make-message
-                           {:message_type "http://puppetlabs.com/error_message"
-                            :sender "pcp:///server"
-                            :data description})
-                    in-reply-to-message (assoc :in_reply_to (:id in-reply-to-message)))]
-    (send-message connection error-msg)))
-
-(s/defn handle-delivery-failure
-  "Send an error message with the specified description."
-  [message :- Message sender :- (s/maybe Connection) reason :- s/Str]
-  (sl/maplog :trace (assoc (summarize message)
-                           :type :message-delivery-failure
-                           :reason reason)
-             (i18n/trs "Failed to deliver '{messageid}' for '{destination}': '{reason}'"))
-  (send-error-message message reason sender))
-
-(s/defn deliver-message
-  "Message consumer. Delivers a message to the websocket indicated by the :target field"
-  [broker :- Broker
-   message :- Message
-   sender :- (s/maybe Connection)]
-  (assert (not (multicast-message? message)))
-  (if-let [connection (get-connection broker (:target message))]
-    (try
-      (sl/maplog
-       :debug (merge (summarize message)
-                     (connection/summarize connection)
-                     {:type :message-delivery})
-       (i18n/trs "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"))
-      (locking (:websocket connection)
-        (time! (:on-send (:metrics broker))
-               (send-message connection message)))
-      (catch Exception e
-        (sl/maplog :error e
-                   {:type :message-delivery-error}
-                   (i18n/trs "Error in deliver-message"))
-        (handle-delivery-failure message sender (str e))))
-    (handle-delivery-failure message sender (i18n/trs "not connected"))))
 
 (s/defn session-association-request? :- s/Bool
   "Return true if message is a session association message"
@@ -186,7 +100,7 @@
 (s/defn reason-to-deny-association :- (s/maybe s/Str)
   "Returns an error message describing why the session should not be
   allowed, if it should be denied"
-  [broker :- Broker connection :- Connection as :- p/Uri]
+  [_ :- Broker connection :- Connection as :- p/Uri]
   (let [[_ type] (p/explode-uri as)]
     (when (not= type (ws->client-type (:websocket connection)))
       (let [{:keys [uri]} connection]
@@ -226,7 +140,7 @@
    (let [requester-uri (:sender message)
          reason-to-deny (reason-to-deny-association broker connection requester-uri)]
      (process-associate-request! broker message connection reason-to-deny)))
-  ([broker :- Broker
+  ([_ :- Broker
     request :- Message
     connection :- Connection
     reason-to-deny :- (s/maybe s/Str)]
@@ -252,11 +166,6 @@
          nil)
        (assoc connection :uri requester-uri)))))
 
-(s/defn make-inventory_response-data-content :- p/InventoryResponse
-  [broker query]
-  {:uris (doall (filter (partial get-connection broker)
-                        (inventory/find-clients broker query)))})
-
 (s/defn process-inventory-request
   "Process a request for inventory data.
    This function assumes that the requester client is associated.
@@ -267,14 +176,17 @@
   (let [data (:data message)]
     (s/validate p/InventoryRequest data)
     (let [requester-uri (:sender message)
-          response-data (make-inventory_response-data-content broker (:query data))
+          pattern-sets (inventory/build-pattern-sets (:query data))
+          inventory (if (:subscribe data)
+                      (inventory/subscribe-client broker requester-uri connection pattern-sets)
+                      (inventory/get-snapshot broker true))
+          data (inventory/build-inventory-data inventory pattern-sets)
           response (message/make-message
                     {:message_type "http://puppetlabs.com/inventory_response"
                      :target requester-uri
                      :in_reply_to (:id message)
-                     :sender "pcp:///server"
-                     :data response-data})]
-      (deliver-message broker response connection)))
+                     :data data})]
+      (deliver-server-message broker response connection)))
   nil)
 
 (s/defn process-server-message! :- (s/maybe Connection)
@@ -591,13 +503,14 @@
                 get-route
                 get-metrics-registry
                 ssl-cert]} options]
-    (let [broker             {:broker-name         broker-name
-                              :authorization-check authorization-check
-                              :metrics             {}
-                              :metrics-registry    (get-metrics-registry)
-                              :inventory           (ConcurrentHashMap.)
-                              :state               (atom :starting)}
-          metrics            (build-and-register-metrics broker)
+    (let [broker             (-> {:broker-name         broker-name
+                                  :authorization-check authorization-check
+                                  :metrics             {}
+                                  :metrics-registry    (get-metrics-registry)
+                                  :routing-map         (ConcurrentHashMap.)
+                                  :state               (atom :starting)}
+                                 inventory/init)
+          metrics            (shared/build-and-register-metrics broker)
           broker             (assoc broker :metrics metrics)]
       (add-websocket-handler (build-websocket-handlers broker message/v1-codec) {:route-id :v1})
       (try
@@ -610,13 +523,13 @@
 
 (s/defn start
   [broker :- Broker]
-  (let [{:keys [state]} broker]
-    (reset! state :running)))
+  (inventory/start-inventory-updates! broker)
+  (-> broker :state (reset! :running)))
 
 (s/defn stop
   [broker :- Broker]
-  (let [{:keys [state]} broker]
-    (reset! state :stopping)))
+  (-> broker :state (reset! :stopping))
+  (inventory/stop-inventory-updates! broker))
 
 (s/defn status :- status-core/StatusCallbackResponse
   [broker :- Broker level :- status-core/ServiceStatusDetailLevel]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -179,7 +179,8 @@
           pattern-sets (inventory/build-pattern-sets (:query data))
           inventory (if (:subscribe data)
                       (inventory/subscribe-client broker requester-uri connection pattern-sets)
-                      (inventory/get-snapshot broker true))
+                      (do (inventory/unsubscribe-client broker requester-uri)
+                          (inventory/get-snapshot broker true)))
           data (inventory/build-inventory-data inventory pattern-sets)
           response (message/make-message
                     {:message_type "http://puppetlabs.com/inventory_response"

--- a/src/puppetlabs/pcp/broker/inventory.clj
+++ b/src/puppetlabs/pcp/broker/inventory.clj
@@ -165,6 +165,17 @@
 ;;   subscriptions
 ;;   inventory
 ;;   updates
+(s/defn unsubscribe-client
+  "Unsubscribe the specified client form inventory updates."
+  [broker :- Broker client :- p/Uri]
+  (let [subscriptions (get-subscriptions broker)]
+    (locking subscriptions
+      (.remove subscriptions client))))
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
 (s/defn ^:private get-subscribers :- [p/Uri]
   "Get a list of clients subscribed for inventory updates."
   [broker :- Broker]

--- a/src/puppetlabs/pcp/broker/inventory.clj
+++ b/src/puppetlabs/pcp/broker/inventory.clj
@@ -1,20 +1,255 @@
 (ns puppetlabs.pcp.broker.inventory
   (:require [puppetlabs.pcp.protocol :as p]
-            [clojure.set :refer [intersection union]]))
+            [puppetlabs.pcp.broker.shared :refer [Broker get-connection deliver-server-message]]
+            [puppetlabs.pcp.broker.message :as message]
+            [clojure.set :refer [intersection union]]
+            [schema.core :as s])
+  (:import [puppetlabs.pcp.broker.connection Connection]
+           [java.util HashSet HashMap LinkedList]
+           [java.util.concurrent ConcurrentLinkedDeque]))
 
-(defn endpoint-pattern-match?
-  "Does an endpoint pattern match the subject value. Here is where wildcards happen"
-  [pattern subject]
-  (let [[pattern-client pattern-type] (p/explode-uri pattern)
-        [subject-client subject-type] (p/explode-uri subject)]
-    (and (some (partial = pattern-client) ["*" subject-client])
-         (some (partial = pattern-type)   ["*" subject-type]))))
+(def PatternSets
+  {:explicit #{p/Uri} :wildcard #{p/ExplodedUri}})
 
-(defn find-clients
-  [{:keys [inventory]} patterns]
-  (let [explicit (set (filter (complement p/uri-wildcard?) patterns))
-        wildcard (set (filter p/uri-wildcard? patterns))
-        uris (set (keys inventory))
-        explicit-matched (intersection explicit uris)
-        wildcard-matched (flatten (map #(filter (partial endpoint-pattern-match? %) uris) wildcard))]
-    (sort (union explicit-matched (set wildcard-matched)))))
+(s/defn init :- Broker
+  [incomplete-broker]                                       ;; the passed broker isn't fully initialized yet
+  (assoc incomplete-broker
+    :inventory     (HashSet.)                               ;; Set of known clients (Uris) used for inventory reports
+    :changes       (ConcurrentLinkedDeque.)                 ;; Queue of pending updates of the :inventory set
+    :updates       (LinkedList.)                            ;; Queue of updates to be sent to the clients subscribed to inventory updates
+    :subscriptions (HashMap.)                               ;; Mapping of subscribed client Uri to subscription data
+    :should-stop   (promise)))
+
+(s/defn ^:private get-inventory :- HashSet
+  [broker :- Broker]
+  (:inventory broker))
+
+(s/defn ^:private get-changes :- ConcurrentLinkedDeque
+  [broker :- Broker]
+  (:changes broker))
+
+(s/defn ^:private get-updates :- LinkedList
+  [broker :- Broker]
+  (:updates broker))
+
+(s/defn ^:private get-subscriptions :- HashMap
+  [broker :- Broker]
+  (:subscriptions broker))
+
+(s/defn add-client
+  [broker :- Broker client :- p/Uri]
+  (let [changes (get-changes broker)]
+    (.offer changes {:client client :change 1})))
+
+(s/defn remove-client
+  [broker :- Broker client :- p/Uri]
+  (let [changes (get-changes broker)]
+    (.offer changes {:client client :change -1})))
+
+(s/defn build-pattern-sets :- PatternSets
+  "Parse the passed patterns and split them into explicit and wildcard sets for faster matching."
+  [patterns :- [p/Uri]]
+  (loop [explicit (transient #{}) wildcard (transient #{}) patterns (seq patterns)]
+    (if patterns
+      (let [pattern (first patterns)]
+        (if-let [exploded-pattern (p/uri-wildcard? pattern)]
+          (recur explicit (conj! wildcard exploded-pattern) (next patterns))
+          (recur (conj! explicit pattern) wildcard (next patterns))))
+      {:explicit (persistent! explicit) :wildcard (persistent! wildcard)})))
+
+(s/defn ^:private exploded-uri-pattern-match? :- s/Bool
+  "Does an exploded subject uri value match the exploded pattern? Here is where wildcards happen."
+  [exploded-pattern :- p/ExplodedUri exploded-subject :- p/ExplodedUri]
+  (let [[pattern-client pattern-type] exploded-pattern
+        [subject-client subject-type] exploded-subject]
+    (and (or (= "*" pattern-client) (= subject-client pattern-client))
+         (or (= "*" pattern-type)   (= subject-type pattern-type)))))
+
+(s/defn uri-pattern-sets-match? :- s/Bool
+  "Does a subject uri match the pattern sets?"
+  [{:keys [explicit wildcard]} :- PatternSets subject :- p/Uri]
+  (or (contains? explicit subject)                          ;; the set of explicit patterns contains the subject
+      (let [exploded-subject (p/explode-uri subject)]
+        (some #(exploded-uri-pattern-match? % exploded-subject) wildcard))
+      false))                                               ;; to satisfy the s/Bool schema for the return value
+
+(s/defn build-inventory-data :- p/InventoryResponse
+  "Build the payload of the inventory response message given the inventory snapshot and
+  a set of patterns to filter the snapshot."
+  [inventory :- #{p/Uri} pattern-sets :- PatternSets]
+  (let [matched (->> inventory
+                     (reduce
+                       (fn [matched-clients client]
+                         (if (uri-pattern-sets-match? pattern-sets client)
+                           (conj! matched-clients client)
+                           matched-clients))
+                       (transient #{}))
+                     persistent!)]
+    {:uris (sort matched)}))
+
+(s/defn ^:private shift-subscription-next-update :- (s/pred nil?)
+  "Change the :next-update key in the subscription HashMap by the specified shift."
+  [subscription :- HashMap next-update-shift :- s/Int]
+  (->> (.get subscription :next-update)
+       (+ next-update-shift)
+       (.put subscription :next-update))
+  nil)                                                      ;; we rely on nil being returned from this function
+
+(s/defn build-update-data :- (s/maybe p/InventoryUpdate)
+  "Build the payload of the inventory update message given the inventory updates snapshot and
+  a set of patterns to filter the snapshot. Return nil if there are no updates matching the
+  patterns."
+  [updates :- [p/InventoryChange] subscription :- HashMap]
+  (let [updates-count (count updates)
+        next-update (:next-update subscription)]
+    (if (< next-update updates-count)                       ;; do we have any new updates for this subscription?
+      (let [pattern-sets (:pattern-sets subscription)
+            filtered (->> (subvec updates next-update)      ;; skip updates which have already been sent to this subscription
+                          (reduce
+                            (fn [filtered-updates update]
+                              (if (uri-pattern-sets-match? pattern-sets (:client update))
+                                ;; FIXME there should be a limit on the maximum number of elements
+                                ;; in the filtered vector to ensure the update message can't grow
+                                ;; too long
+                                (conj! filtered-updates update)
+                                filtered-updates))
+                            (transient []))
+                          persistent!)
+            next-update-shift (- updates-count next-update)]
+        (if (seq filtered)
+          (with-meta {:changes filtered} {:next-update-shift next-update-shift})
+          (shift-subscription-next-update subscription next-update-shift)))))) ;; this returns nil
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
+(s/defn get-snapshot :- (s/either #{p/Uri} [p/InventoryChange])
+  "Process the pending inventory changes to update the inventory and the updates queue
+  and return a copy of one or the other depending on the value of the inventory-snapshot?
+  argument."
+  [broker :- Broker inventory-snapshot? :- s/Bool]
+  (let [changes (get-changes broker)
+        inventory (get-inventory broker)
+        updates (get-updates broker)]
+    (locking inventory
+      (locking updates
+        (dotimes [_ (.size changes)]
+          (let [change (.remove changes)]
+            (if (pos? (:change change))
+              (.add inventory (:client change))
+              (.remove inventory (:client change)))
+            (.add updates change)))
+        (if inventory-snapshot?
+          (with-meta (into #{} inventory) {:next-update (.size updates)})
+          (into [] updates))))))
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
+(s/defn subscribe-client :- #{p/Uri}
+  "Subscribe the specified client for inventory updates. Return the inventory snapshot
+  at the time of subscribing."
+  [broker :- Broker client :- p/Uri connection :- Connection pattern-sets :- PatternSets]
+  (let [subscriptions (get-subscriptions broker)]
+    (locking subscriptions
+      (let [inventory (get-snapshot broker true)]
+        (.put subscriptions client
+              (HashMap. {:connection   connection
+                         :pattern-sets pattern-sets
+                         :next-update  (-> inventory meta :next-update)}))
+        inventory))))
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
+(s/defn ^:private get-subscribers :- [p/Uri]
+  "Get a list of clients subscribed for inventory updates."
+  [broker :- Broker]
+  (let [subscriptions (get-subscriptions broker)]
+    (locking subscriptions
+      (into () (.keySet subscriptions)))))
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
+(s/defn ^:private get-subscription :- HashMap
+  "Get a subscription HashMap given a subscriber Uri."
+  [broker :- Broker subscriber :- p/Uri]
+  (let [subscriptions (get-subscriptions broker)]
+    (locking subscriptions
+      (if-let [^HashMap subscription (.get subscriptions subscriber)]
+        (let [connection (.get subscription :connection)]
+          (if (identical? connection (get-connection broker subscriber))
+            subscription
+            (do (.remove subscriptions subscriber) nil))))))) ;; the client has disconnected or reconnected
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
+(s/defn ^:private remove-processed-updates
+  "Remove the specified number of update records from the updates queue and update the :next-update
+  offsets in all subscriptions accordingly."
+  [broker :- Broker processed-updates-count :- s/Int]
+  (let [subscriptions (get-subscriptions broker)
+        updates (get-updates broker)]
+    (locking subscriptions
+      (locking updates
+        (-> updates (.subList 0 processed-updates-count) .clear))
+      (let [processed-updates-count (- processed-updates-count)] ;; negate the processed-updates-count
+        (doseq [^HashMap subscription (.values subscriptions)]
+          (shift-subscription-next-update subscription processed-updates-count)))))) ;; adding negation i.e. subtracting
+
+(s/defn ^:private send-updates
+  [broker :- Broker]
+  "Send inventory update messages to subscribed clients. Subsequently remove the processed inventory
+  change records from the updates queue."
+  (let [updates (get-snapshot broker false)]
+    (->> (reduce                                            ;; this reduce returns the number of updates which can be removed from the updates queue
+           (fn [processed-updates-count subscriber]
+             (or (if-let [subscription (get-subscription broker subscriber)]
+                   (if-let [data (build-update-data updates subscription)]
+                     (let [message (message/make-message
+                                     {:message_type "http://puppetlabs.com/inventory_update"
+                                      :target subscriber
+                                      :data data})
+                           next-update (.get subscription :next-update)]
+                       (if (deliver-server-message broker message (.get subscription :connection))
+                         (shift-subscription-next-update subscription (-> data meta :next-update-shift)) ;; this returns nil
+                         ;; since we failed to send the update to the client we can't remove the update entries
+                         ;; we failed to send from the update queue so that we can re-try during the next iteration;
+                         ;; so we only allow removal of the entries before the :next-update value of this subscription
+                         ;; (actually the lesser of that value and a value accumulated from previous iterations in
+                         ;; case there were other similarly affected subscriptions)
+                         (min processed-updates-count next-update)))))
+                 processed-updates-count))
+           (count updates)
+           (get-subscribers broker))
+         (remove-processed-updates broker))))
+
+(s/defn start-inventory-updates!
+  "Start periodic sending of the inventory updates."
+  [broker :- Broker]
+  (future
+    (let [should-stop (:should-stop broker)
+          timeout (Object.)]
+      (loop []
+        (send-updates broker)
+        (if (identical? (deref should-stop 1000 timeout) timeout)
+          (recur))))))
+
+;; N.B. locking order:
+;;   subscriptions
+;;   inventory
+;;   updates
+(s/defn stop-inventory-updates!
+  "Stop the periodic sending of the inventory updates."
+  [broker :- Broker]
+  (let [subscriptions (get-subscriptions broker)]
+    (locking subscriptions
+      (.clear subscriptions)))
+  (deliver (:should-stop broker) nil))

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -1,0 +1,156 @@
+(ns puppetlabs.pcp.broker.shared
+  (:require [metrics.gauges :as gauges]
+            [puppetlabs.experimental.websockets.client :as websockets-client]
+            [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
+            [puppetlabs.pcp.broker.websocket :refer [Websocket ws->uri ws->client-type]]
+            [puppetlabs.pcp.broker.message :as message :refer [Message multicast-message?]]
+            [puppetlabs.pcp.protocol :as p]
+            [puppetlabs.metrics :refer [time!]]
+            [puppetlabs.structured-logging.core :as sl]
+            [schema.core :as s]
+            [puppetlabs.i18n.core :as i18n])
+  (:import [puppetlabs.pcp.broker.connection Connection]
+           [clojure.lang IFn Atom]
+           [java.util HashSet HashMap LinkedList]
+           [java.util.concurrent ConcurrentHashMap ConcurrentLinkedDeque]))
+
+(def BrokerState
+  (s/enum :starting :running :stopping))
+
+(def Broker
+  {:broker-name         (s/maybe s/Str)
+   :authorization-check IFn
+   :routing-map         ConcurrentHashMap                   ;; Mapping of Uri to Connection
+   :inventory           HashSet                             ;; Set of known clients (Uris) used for inventory reports
+   :changes             ConcurrentLinkedDeque               ;; Queue of pending updates of the :inventory set
+   :updates             LinkedList                          ;; Queue of updates to be sent to the clients subscribed to invetory updates
+   :subscriptions       HashMap                             ;; Mapping of subscribed client Uri to subscription data
+   :should-stop         Object                              ;; Promise used to signal the inventory updates should stop
+   :metrics-registry    Object
+   :metrics             {s/Keyword Object}
+   :state               (s/atom BrokerState)})
+
+(s/defn get-routing-map :- ConcurrentHashMap
+  [broker :- Broker]
+  (:routing-map broker))
+
+(s/defn get-connection :- (s/maybe Connection)
+  [broker :- Broker
+   uri :- p/Uri]
+  (.get (get-routing-map broker) uri))
+
+(s/defn build-and-register-metrics :- {s/Keyword Object}
+  [broker :- Broker]
+  (let [registry (:metrics-registry broker)
+        routing-map (get-routing-map broker)]
+    (gauges/gauge-fn registry ["puppetlabs.pcp.connections"]
+                     (fn [] (.size routing-map)))
+    {:on-connect       (.timer registry "puppetlabs.pcp.on-connect")
+     :on-close         (.timer registry "puppetlabs.pcp.on-close")
+     :on-message       (.timer registry "puppetlabs.pcp.on-message")
+     :on-send          (.timer registry "puppetlabs.pcp.on-send")}))
+
+;;
+;; Message sending
+;;
+
+(def MessageLog
+  "Schema for a loggable summary of a message"
+  {:messageid p/MessageId
+   :source s/Str
+   :messagetype s/Str
+   :destination p/Uri})
+
+(s/defn summarize :- MessageLog
+  [message :- Message]
+  {:messageid (:id message)
+   :messagetype (:message_type message)
+   :source (:sender message)
+   :destination (:target message)})
+
+(s/defn send-message
+  [connection :- Connection
+   message :- Message]
+  (sl/maplog :trace {:type :outgoing-message-trace
+                     :uri (ws->uri (:websocket connection))
+                     :rawmsg message}
+             (i18n/trs "Sending PCP message to '{uri}': '{rawmsg}'"))
+  (websockets-client/send! (:websocket connection)
+                           ((get-in connection [:codec :encode]) message))
+  nil)
+
+(s/defn send-error-message
+  [in-reply-to-message :- (s/maybe Message)
+   description :- s/Str
+   connection :- Connection]
+  (let [error-msg (cond-> (message/make-message
+                           {:message_type "http://puppetlabs.com/error_message"
+                            :sender "pcp:///server"
+                            :data description})
+                    in-reply-to-message (assoc :in_reply_to (:id in-reply-to-message)))]
+    (send-message connection error-msg)))
+
+(s/defn log-delivery-failure
+  "Log message delivery failure given the message and failure reason."
+  [message :- Message reason :- s/Str]
+  (sl/maplog :trace (assoc (summarize message)
+                      :type :message-delivery-failure
+                      :reason reason)
+             (i18n/trs "Failed to deliver '{messageid}' for '{destination}': '{reason}'"))
+  nil)                                                      ;; ensure nil is returned
+
+(s/defn handle-delivery-failure
+  "Send an error message with the specified description."
+  [message :- Message sender :- (s/maybe Connection) reason :- s/Str]
+  (log-delivery-failure message reason)
+  (send-error-message message reason sender))
+
+(s/defn deliver-message
+  "Message consumer. Delivers a message to the websocket indicated by the :target field"
+  [broker :- Broker
+   message :- Message
+   sender :- (s/maybe Connection)]
+  (assert (not (multicast-message? message)))
+  (if-let [connection (get-connection broker (:target message))]
+    (try
+      (sl/maplog
+       :debug (merge (summarize message)
+                     (connection/summarize connection)
+                     {:type :message-delivery})
+       (i18n/trs "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"))
+      (locking (:websocket connection)
+        (time! (:on-send (:metrics broker))
+               (send-message connection message)))
+      (catch Exception e
+        (sl/maplog :error e
+                   {:type :message-delivery-error}
+                   (i18n/trs "Error in deliver-message"))
+        (handle-delivery-failure message sender (str e))))
+    (handle-delivery-failure message sender (i18n/trs "not connected"))))
+
+(s/defn deliver-server-message
+  "Message consumer. Delivers a message to the websocket indicated by the :target field but only if it still
+  routed to the conection specified by the client argument"
+  [broker :- Broker
+   message :- Message
+   client :- Connection]
+  (assert (not (multicast-message? message)))
+  (let [connection (get-connection broker (:target message))
+        message (assoc message :sender "pcp:///server")]
+    (if (identical? connection client)
+      (try
+        (sl/maplog
+          :debug (merge (summarize message)
+                        (connection/summarize connection)
+                        {:type :message-delivery})
+          (i18n/trs "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"))
+        (locking (:websocket connection)
+          (time! (:on-send (:metrics broker))
+                 (send-message connection message))
+          true)
+        (catch Exception e
+          (sl/maplog :error e
+                     {:type :message-delivery-error}
+                     (i18n/trs "Error in deliver-message"))
+          (log-delivery-failure message (str e))))
+      (log-delivery-failure message (i18n/trs "client no longer connected")))))

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -370,6 +370,100 @@
                    (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
                    (is (= [] (:uris data))))))))
 
+(deftest inventory-node-recieves-updates-when-inventory-changes-when-subscribed-to-updates
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+               (with-open [client (client/connect :certname "client01.example.com"
+                                                  :version version)]
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client01.example.com/agent"
+                                  :data {:query ["pcp://client02.example.com/agent"]
+                                         :subscribe true}})]
+                   (client/send! client request))
+                 (let [response (client/recv! client)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= [] (:uris data))))
+                 (with-open [client2 (client/connect :certname "client02.example.com"
+                                                    :version version)]
+                   (let [response (client/recv! client)
+                         data (client/get-data response version)]
+                     (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                     (is (= [{:client "pcp://client02.example.com/agent" :change 1}] (:changes data)))))
+                 (let [response (client/recv! client)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client02.example.com/agent" :change -1}] (:changes data))))))))
+
+(deftest inventory-updates-are-properly-filtered
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+               (with-open [client1 (client/connect :certname "client01.example.com"
+                                                   :version version)
+                           client2 (client/connect :certname "client02.example.com"
+                                                   :version version)]
+                 ;; subscribe client1 for updates with a specific filter
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client01.example.com/agent"
+                                  :data {:query ["pcp://client04.example.com/*"]
+                                         :subscribe true}})]
+                   (client/send! client1 request))
+                 (let [response (client/recv! client1)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= [] (:uris data))))
+
+                 ;; subscribe client2 for updates with a match all filter
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client02.example.com/agent"
+                                  :data {:query ["pcp://*/agent"]
+                                         :subscribe true}})]
+                   (client/send! client2 request))
+                 (let [response (client/recv! client2)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= ["pcp://client01.example.com/agent" "pcp://client02.example.com/agent"] (:uris data))))
+
+                 ;; now connect a client matching only the filter client2 used for subscribing
+                 (with-open [client3 (client/connect :certname "client03.example.com"
+                                                     :version version)]
+                   (let [response (client/recv! client2)
+                         data (client/get-data response version)]
+                     (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                     (is (= [{:client "pcp://client03.example.com/agent" :change 1}] (:changes data))))
+                   ;; client1 doesn't receive an update at all, becuase the change doesn't match its filter
+                   (let [response (client/recv! client1 3000)]
+                     (is (nil? response)))
+                   (with-open [client4 (client/connect :certname "client04.example.com"
+                                                       :version version)]
+                     (let [response (client/recv! client2)
+                           data (client/get-data response version)]
+                       (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                       (is (= [{:client "pcp://client04.example.com/agent" :change 1}] (:changes data))))
+                     (let [response (client/recv! client1)
+                           data (client/get-data response version)]
+                       (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                       (is (= [{:client "pcp://client04.example.com/agent" :change 1}] (:changes data))))))
+                 ;; client4 & client3 have disconnected (in that order)
+                 (let [response (client/recv! client2)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client04.example.com/agent" :change -1}
+                           {:client "pcp://client03.example.com/agent" :change -1}] (:changes data))))
+                 (let [response (client/recv! client1)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client04.example.com/agent" :change -1}] (:changes data))))))))
+
 (def no-inventory-broker-config
   "A broker that allows connections but no inventory requests"
   (assoc-in broker-config [:authorization :rules]

--- a/test/unit/puppetlabs/pcp/broker/message_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/message_test.clj
@@ -1,29 +1,29 @@
-(ns puppetlabs.pcp.broker.core-test
+(ns puppetlabs.pcp.broker.message-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.broker.message :as message]))
+            [puppetlabs.pcp.broker.message :refer :all]))
 
 (deftest multicast-message?-test
   (testing "returns false if target specifies a single host with no wildcards"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:target "pcp://example01.example.com/foo"})]
       (is (not (multicast-message? message)))))
   (testing "returns true if target includes wildcard hostname"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:target "pcp://*/foo"})]
       (is (multicast-message? message))))
   (testing "returns true if target includes wildcard client type"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:target "pcp://example01.example.com/*"})]
       (is (multicast-message? message))))
   (testing "returns true if multicast-message key is inserted"
-    (let [message (message/make-message
-                   {:target "pcp://example01.example.com/agent"
-                    :multicast-message true})]
+    (let [message (-> (make-message
+                       {:target "pcp://example01.example.com/agent"})
+                      (assoc :multicast-message true))]
       (is (multicast-message? message)))))
 
 (deftest message-roundtrip-test
   (testing "message survives v1 roundtrip"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:sender "pcp://gangoffour/entity"
                     :message_type "ether"
                     :target "pcp://gangoffour/entity"})]
@@ -31,7 +31,7 @@
                          v1-encode
                          v1-decode)))))
   (testing "message survives v2 roundtrip"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:sender "pcp://gangoffour/entity"
                     :message_type "ether"
                     :target "pcp://gangoffour/entity"})]

--- a/test/unit/puppetlabs/pcp/broker/shared_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/shared_test.clj
@@ -1,0 +1,92 @@
+(ns puppetlabs.pcp.broker.shared-test
+  (:require [clojure.test :refer :all]
+            [metrics.core]
+            [puppetlabs.pcp.testutils :refer [dotestseq]]
+            [puppetlabs.pcp.broker.shared :refer :all]
+            [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
+            [puppetlabs.pcp.broker.inventory :as inventory]
+            [puppetlabs.pcp.broker.websocket :refer [ws->uri]]
+            [puppetlabs.pcp.broker.message :as message]
+            [puppetlabs.kitchensink.core :as ks]
+            [schema.core :as s]
+            [slingshot.test])
+  (:import [puppetlabs.pcp.broker.connection Connection]
+           [java.util.concurrent ConcurrentHashMap]))
+
+(def mock-uri "pcp://foo.com/agent")
+(defn mock-ws->uri [_] mock-uri)
+
+(s/defn dummy-connection-from :- Connection
+  [common-name]
+  (assoc (connection/make-connection :dummy-ws message/v2-codec)
+    :common-name common-name))
+
+(s/defn make-test-broker :- Broker
+  "Return a minimal clean broker state"
+  []
+  (let [broker (-> {:broker-name         nil
+                    :authorization-check (constantly true)
+                    :routing-map         (ConcurrentHashMap.)
+                    :metrics-registry    metrics.core/default-registry
+                    :metrics             {}
+                    :state               (atom :running)}
+                   inventory/init)
+        metrics (build-and-register-metrics broker)
+        broker (assoc broker :metrics metrics)]
+    broker))
+
+(deftest handle-delivery-failure-test
+  (let [_ (make-test-broker)
+        msg (message/make-message)
+        delivered (atom [])]
+    (with-redefs [puppetlabs.pcp.broker.shared/send-error-message
+                  (fn [mg _ _]
+                    (swap! delivered conj mg))]
+      (testing "redelivery always"
+        (handle-delivery-failure msg nil "Out of cheese")
+        (is (= 1 (count @delivered)))))))
+
+(deftest deliver-message-test
+  (let [broker (make-test-broker)
+        failure (atom nil)]
+    (testing "delivers messages"
+      (let [message (message/make-message
+                     {:target "pcp://example01.example.com/foo"})]
+        (with-redefs [puppetlabs.pcp.broker.shared/handle-delivery-failure
+                      (fn [_ _ err] (reset! failure err))]
+          (deliver-message broker message nil)
+          (is (= "not connected" @failure)))))
+    (testing "errors if multicast message"
+      (let [message (message/make-message)]
+        (with-redefs [puppetlabs.pcp.broker.message/multicast-message?  (fn [_] true)]
+          (is (thrown? java.lang.AssertionError (deliver-message broker message nil))))))))
+
+(deftest send-error-message-test
+  (with-redefs [ws->uri mock-ws->uri]
+    (let [error-msg (atom nil)
+          connection (dummy-connection-from "host_x")]
+      (with-redefs [puppetlabs.experimental.websockets.client/send!
+                    (fn [_ raw-message]
+                      (reset! error-msg (message/v2-decode raw-message)))]
+        (testing "sends error_message correctly and returns nil if received msg is NOT given"
+          (let [received-msg nil
+                error-description "something wrong!"
+                outcome (send-error-message received-msg error-description connection)
+                msg-data (:data @error-msg)]
+            (is (nil? outcome))
+            (is (not (contains? @error-msg :in_reply_to)))
+            (is (= error-description msg-data))))
+        (testing "sends error_message correctly and returns nil if received msg is given"
+          (reset! error-msg nil)
+          (let [the-uuid (ks/uuid)
+                received-msg (message/make-message
+                              {:sender "pcp://test_example/pcp_client_alpha"
+                               :message_type "gossip"
+                               :target "pcp://test_broker/server"})
+                received-msg (assoc received-msg :id the-uuid)
+                error-description "something really wrong :o"
+                outcome (send-error-message received-msg error-description connection)
+                msg-data (:data @error-msg)]
+            (is (nil? outcome))
+            (is (= the-uuid (:in_reply_to @error-msg)))
+            (is (= error-description msg-data))))))))


### PR DESCRIPTION
This PR introduces support for inventory updates. Here is an outline of the used data structures and the operation.

## The used data structures:
- `:routing-map` (ConcurrentHashMap) a map of client Uri to websocket connection, used for message routing; the structure supports parallel updates, but it's impossible to obtain a consistent view of it without locking it globally, which is not done so as not to sacrifice performance which means it's not suitable for building the inventory responses (which need to be consistent especially when subscribing for periodic updates)
- `:changes` (ConcurrentLinkedDeque) a queue of changes to the :routing-map (essentially a serialization of the client connection and disconnection events) which serves as a buffer between the parallel capable but inherently inconsistent :routing-map and the :inventory and :updates data structures described below, it can handle parallel updates and for performance reasons is never locked globally either
- `:inventory` (HashSet) a set of the Uris of the clients known to the broker; this structure is populated by applying the changes accumulated in the :changes queue at appropriate times; it can be (and must be) locked globally when its state is modified or read but as a result its consistent view can be obtained
- `:updates` (LinkedList) a queue of the same update events as in the :changes queue, the events are added to it at the same times the :inventory set is updated, it must be locked globally when updated or read but similarly to the :inventory this makes it possible to obtain its consistent view
- `:subscriptions` (HashMap) a map of client Uri to subscription record, which stores the following pieces of information:
  - `:connection`, the websocket connection on which the subscription was received, this is used to detect stale subscriptions
  - `:pattern-sets`, a form of Uri filters of the inventory updates the subscriber is interested in receiving
  - `:next-update`, an offset to the :updates queue of the next update that should be sent to this subscriber (provided that it matches the :pattern-sets)

## The operation:
- when a client connects/disconnects a mapping is added to/removed from the :routing-map structure and an appropriate event record is added to the :changes queue; note that these structures are designed to handle parallel updates so no explicit locking of those is needed
- when an inventory request is received then events accumulated in the :changes queue are applied to the :inventory and :updates structures to obtain their up-to-date yet consistent views, subsequently the inventory response is composed from the :inventory view (or snapshot as it is referred to in the code); if the periodic updates are requested, the client is added to the :subscriptions map, the :next-update in the subscription record is set to the length of the :updates queue (as all the previous updates are already reflected in the inventory snapshot)
- updates are sent periodically to subscribed clients, on each iteration the events accumulated in the :changes queue are applied to the :inventory and :updates structures to obtain their up-to-date yet consistent views, then the view of the :updates queue is used to compose the update messages for each subscribed client, the :next-update offset of each subscription is updated as the corresponding inventory update message is sent, when updates are sent to all subscribed clients the processed records from the :updates queue are removed and the :next-update offsets of all subscriptions are updated accordingly