### PR TITLE
(maint) Log normal failure mode, remove cond-let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.1
+
+This is a maintenane release
+
+* Logs failure to deliver error messages and associate response to debug. These
+are normal behavior if the client disconnects after sending a message.
+
 ## 1.0.0
 
 This is a major breaking release with significant new features. It introduces

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -22,6 +22,10 @@ msgid "Sending PCP message to '{uri}': '{rawmsg}'"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
+msgid "Error in send-error-message"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
 msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
 msgstr ""
 
@@ -45,6 +49,10 @@ msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Session already associated"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Error in process-associate-request!"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,6 @@
                  [cheshire]
 
                  [com.taoensso/nippy "2.9.0"]
-                 [io.aviso/toolchest "0.1.5"]
 
                  [metrics-clojure "2.5.1"]
 

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -142,7 +142,12 @@
                             :sender "pcp:///server"
                             :data description})
                     in-reply-to-message (assoc :in_reply_to (:id in-reply-to-message)))]
-    (send-message connection error-msg)))
+    (try
+      (send-message connection error-msg)
+      (catch Exception e
+        (sl/maplog :debug e
+                   {:type :message-delivery-error}
+                   (i18n/trs "Error in send-error-message"))))))
 
 (s/defn handle-delivery-failure
   "Send an error message with the specified description."
@@ -240,7 +245,12 @@
                    :in_reply_to id
                    :sender "pcp:///server"
                    :data response-data})]
-     (send-message connection message)
+     (try
+       (send-message connection message)
+       (catch Exception e
+         (sl/maplog :debug e
+                    {:type :message-delivery-error}
+                    (i18n/trs "Error in process-associate-request!"))))
      (if reason-to-deny
        (do
          (sl/maplog


### PR DESCRIPTION
Catch and add debug logging when messages can't be delivered because the
connection is no longer available. It's normal operation for a client to
disconnect and leave an undeliverable response.

Observed some suspicious behavior in clj-pxp-puppet tests that might
have been related to the cond-let implementation. It doesn't improve the
code much, so remove it in place of nested ifs.