### PR TITLE
(maint) Fix test client

### DIFF
--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -21,7 +21,7 @@
     </root>
 
     <logger name="puppetlabs.pcp.client" level="warn"/>
-    <logger name="puppetlabs.pcp.broker" level="trace"/>
+    <logger name="puppetlabs.pcp.broker" level="warn"/>
     <logger name="puppetlabs.pcp.broker.pcp_access" level="error"/>
     <logger name="puppetlabs.pcp.testutils" level="warn"/>
 </configuration>

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -541,6 +541,7 @@
                (with-open [client01 (client/connect :certname "client01.example.com"
                                                     :version version)
                            client02 (client/connect :certname "client02.example.com"
+                                                    :force-association true
                                                     :version version)]
                  (testing "client01 -> client02 should work"
                    (let [message (client/make-message
@@ -568,6 +569,7 @@
                (with-open [sender   (client/connect :certname "client01.example.com"
                                                     :version sender-version)
                            receiver (client/connect :certname "client02.example.com"
+                                                    :force-association true
                                                     :version receiver-version)]
                  (let [message (client/make-message
                                 sender-version


### PR DESCRIPTION
The test client can't determine when the broker registers a connection
without session association. Force it on tests that depend on multiple
clients being connected at once.