### PR TITLE
(PCP-600) Inventory updates

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -18,30 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "Sending PCP message to '{uri}': '{rawmsg}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Error in send-error-message"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Error in deliver-message"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "not connected"
-msgstr ""
-
-#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Received session association for '{uri}' from '{commonname}' "
 "'{remoteaddress}'. Session was already associated as '{existinguri}'"
@@ -181,4 +157,32 @@ msgstr ""
 
 #: src/puppetlabs/pcp/broker/service.clj
 msgid "Broker service <'{brokername}'> stopped"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Sending PCP message to '{uri}': '{rawmsg}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Error in send-error-message"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Error in deliver-message"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "not connected"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "client no longer connected"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-common "1.0.0"]
+                 [puppetlabs/pcp-common "1.1.0"]
 
                  [puppetlabs/i18n]]
 

--- a/src/puppetlabs/pcp/broker/inventory.clj
+++ b/src/puppetlabs/pcp/broker/inventory.clj
@@ -1,20 +1,177 @@
 (ns puppetlabs.pcp.broker.inventory
   (:require [puppetlabs.pcp.protocol :as p]
-            [clojure.set :refer [intersection union]]))
+            [puppetlabs.pcp.broker.shared :refer [Broker get-connection deliver-server-message] :as shared]
+            [puppetlabs.pcp.broker.message :as message]
+            [clojure.set :refer [intersection union]]
+            [schema.core :as s])
+  (:import [clojure.lang Numbers]
+           [puppetlabs.pcp.broker.connection Connection]))
 
-(defn endpoint-pattern-match?
-  "Does an endpoint pattern match the subject value. Here is where wildcards happen"
-  [pattern subject]
-  (let [[pattern-client pattern-type] (p/explode-uri pattern)
-        [subject-client subject-type] (p/explode-uri subject)]
-    (and (some (partial = pattern-client) ["*" subject-client])
-         (some (partial = pattern-type)   ["*" subject-type]))))
+(s/defn init-database :- shared/BrokerDatabase
+  []
+  {:inventory          {}
+   :updates            []
+   :first-update-index 0
+   :subscriptions      {}})
 
-(defn find-clients
-  [{:keys [inventory]} patterns]
-  (let [explicit (set (filter (complement p/uri-wildcard?) patterns))
-        wildcard (set (filter p/uri-wildcard? patterns))
-        uris (set (keys inventory))
-        explicit-matched (intersection explicit uris)
-        wildcard-matched (flatten (map #(filter (partial endpoint-pattern-match? %) uris) wildcard))]
-    (sort (union explicit-matched (set wildcard-matched)))))
+(s/defn unchecked+ :- s/Int
+  "An addition which can overflow"
+  [a :- s/Int b :- s/Int]
+  (Numbers/unchecked_add (long a) (long b)))
+
+(s/defn unchecked- :- s/Int
+  "A substraction which can overflow"
+  [a :- s/Int b :- s/Int]
+  (Numbers/unchecked_minus (long a) (long b)))
+
+(s/defn build-pattern-sets :- shared/PatternSets
+  "Parse the passed patterns and split them into explicit and wildcard sets for faster matching."
+  [patterns :- [p/Uri]]
+  (loop [explicit (transient #{}) wildcard (transient #{}) patterns (seq patterns)]
+    (if patterns
+      (let [pattern (first patterns)]
+        (if-let [exploded-pattern (p/uri-wildcard? pattern)]
+          (recur explicit (conj! wildcard exploded-pattern) (next patterns))
+          (recur (conj! explicit pattern) wildcard (next patterns))))
+      {:explicit (persistent! explicit) :wildcard (persistent! wildcard)})))
+
+(s/defn ^:private exploded-uri-pattern-match? :- s/Bool
+  "Does an exploded subject uri value match the exploded pattern? Here is where wildcards happen."
+  [exploded-pattern :- p/ExplodedUri exploded-subject :- p/ExplodedUri]
+  (let [[pattern-client pattern-type] exploded-pattern
+        [subject-client subject-type] exploded-subject]
+    (and (or (= "*" pattern-client) (= subject-client pattern-client))
+         (or (= "*" pattern-type)   (= subject-type pattern-type)))))
+
+(s/defn uri-pattern-sets-match? :- s/Bool
+  "Does a subject uri match the pattern sets?"
+  [{:keys [explicit wildcard]} :- shared/PatternSets subject :- p/Uri]
+  (or (contains? explicit subject)                          ;; the set of explicit patterns contains the subject
+      (let [exploded-subject (p/explode-uri subject)]
+        (some #(exploded-uri-pattern-match? % exploded-subject) wildcard))
+      false))                                               ;; to satisfy the s/Bool schema for the return value
+
+(s/defn build-inventory-data :- p/InventoryResponse
+  "Build the payload of the inventory response message given the inventory snapshot and
+  a set of patterns to filter the snapshot."
+  [inventory :- shared/Inventory pattern-sets :- shared/PatternSets]
+  (let [matched (->> inventory
+                     (reduce
+                       (fn [matched-clients [client _]]
+                         (if (uri-pattern-sets-match? pattern-sets client)
+                           (conj! matched-clients client)
+                           matched-clients))
+                       (transient #{}))
+                     persistent!)]
+    {:uris (sort matched)}))
+
+(s/defn build-update-data :- (s/maybe p/InventoryUpdate)
+  "Build the payload of the inventory update message given the inventory updates snapshot and
+  a set of patterns to filter the snapshot. Return nil if there are no updates matching the
+  patterns."
+  [updates :- [p/InventoryChange] pattern-sets :- shared/PatternSets]
+      (let [filtered (->> updates
+                          (reduce
+                            (fn [filtered-updates update]
+                              (if (uri-pattern-sets-match? pattern-sets (:client update))
+                                ;; FIXME there should be a limit on the maximum number of elements
+                                ;; in the filtered vector to ensure the update message can't grow
+                                ;; too long
+                                (conj! filtered-updates update)
+                                filtered-updates))
+                            (transient []))
+                          persistent!)]
+        (if (seq filtered)
+          {:changes filtered})))
+
+(s/defn subscribe-client! :- shared/BrokerDatabase
+  "Subscribe the specified client for inventory updates. Return the broker database snapshot
+  at the time of subscribing."
+  [broker :- Broker client :- p/Uri connection :- Connection pattern-sets :- shared/PatternSets]
+  (let [database (:database broker)]
+    (swap! database
+           #(update % :subscriptions assoc client {:connection        connection
+                                                   :pattern-sets      pattern-sets
+                                                   :next-update-index (unchecked+ (-> % :first-update-index) (-> % :updates count))}))))
+
+(s/defn unsubscribe-client! :- shared/BrokerDatabase
+  "Unsubscribe the specified client from inventory updates. Return the broker database snapshot
+  at the time of unsubscribing."
+  [broker :- Broker client :- p/Uri]
+  (let [database (:database broker)]
+    (swap! database
+           update :subscriptions dissoc client)))
+
+(s/defn ^:private remove-processed-updates
+  "Remove the `processed-updates-count` updates from the :updates vector and increase
+  :first-update-index accordingly."
+  [broker :- Broker processed-updates-count :- s/Int]
+  (let [database (:database broker)]
+    (swap! database #(-> %
+                         ;; need to call vec as the subvec keeps a reference to the original vector
+                         (update :updates (fn [updates] (vec (subvec updates processed-updates-count))))
+                         (update :first-update-index unchecked+ processed-updates-count)))))
+
+(s/defn ^:private send-updates
+  [broker :- Broker]
+  "Send inventory update messages to subscribed clients. Subsequently remove the processed inventory
+  change records from the :updates vector."
+  (let [database (:database broker)
+        database-snapshot @database
+        updates (:updates database-snapshot)
+        updates-count (count updates)
+        first-update-index (:first-update-index database-snapshot)]
+    (->> (reduce                                            ;; this reduce returns the number of updates which can be removed from the :updates vector
+           (fn [processed-updates-count subscriber]
+             (if-let [subscription (-> @database :subscriptions (get subscriber))]
+               (let [next-update-offset (unchecked- (:next-update-index subscription) first-update-index)
+                     processed-count-atom (atom nil)]       ;; how many records from the updates vector were processed
+                 (swap! database
+                        (fn [database]
+                          (if (identical? (-> database :subscriptions (get subscriber)) subscription) ;; is the subscription in the live database still the same?
+                            (do
+                              (if (nil? @processed-count-atom) ;; have we not sent the update to this subscriber yet?
+                                (let [data (-> (subvec updates next-update-offset) ;; skip updates which have already been sent to this subscriber
+                                               (build-update-data (:pattern-sets subscription)))]
+                                  (if (or (nil? data) ;; there are no updates for this subscriber
+                                          (deliver-server-message broker
+                                                                  (message/make-message
+                                                                    {:message_type "http://puppetlabs.com/inventory_update"
+                                                                     :target subscriber
+                                                                     :data data})
+                                                                  (:connection subscription)))
+                                    (reset! processed-count-atom updates-count)
+                                    (reset! processed-count-atom next-update-offset))))
+                              (let [processed-count @processed-count-atom]
+                                (if (> processed-count next-update-offset)
+                                  ;; add the count of the InventoryChange records which were processed when building the
+                                  ;; inventory update for this subscriber to the :next-update-index in the subscription
+                                  (update database :subscriptions assoc subscriber
+                                          (update subscription :next-update-index unchecked+ (- processed-count next-update-offset)))
+                                  database))) ;; no need to update the subscription if nothing past the next-update-offset was processed
+                            (do
+                              ;; if the subscription has been changed, ignore it but pretend the entire updates vector was processed
+                              (reset! processed-count-atom updates-count)
+                              database))))
+                 (min @processed-count-atom processed-updates-count))
+               processed-updates-count))
+           updates-count
+           (-> database-snapshot :subscriptions keys))
+         (remove-processed-updates broker))))
+
+(s/defn start-inventory-updates!
+  "Start periodic sending of the inventory updates."
+  [broker :- Broker]
+  (future
+    (let [should-stop (:should-stop broker)]
+      (loop []
+        (send-updates broker)
+        (if (nil? (deref should-stop 1000 nil))
+          (recur))))))
+
+(s/defn stop-inventory-updates!
+  "Stop the periodic sending of the inventory updates."
+  [broker :- Broker]
+  (let [database (:database broker)]
+    (swap! database assoc :subscriptions {}))         ;; clear all subscriptions
+  (deliver (:should-stop broker) true))

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -1,0 +1,171 @@
+(ns puppetlabs.pcp.broker.shared
+  (:require [metrics.gauges :as gauges]
+            [puppetlabs.experimental.websockets.client :as websockets-client]
+            [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
+            [puppetlabs.pcp.broker.websocket :refer [Websocket ws->uri ws->client-type]]
+            [puppetlabs.pcp.broker.message :as message :refer [Message multicast-message?]]
+            [puppetlabs.pcp.protocol :as p]
+            [puppetlabs.metrics :refer [time!]]
+            [puppetlabs.structured-logging.core :as sl]
+            [schema.core :as s]
+            [puppetlabs.i18n.core :as i18n])
+  (:import [puppetlabs.pcp.broker.connection Connection]
+           [clojure.lang IFn]))
+
+(def BrokerState
+  (s/enum :starting :running :stopping))
+
+(def PatternSets
+  {:explicit #{p/Uri} :wildcard #{p/ExplodedUri}})
+
+(def Subscription
+  {:connection        Connection
+   :pattern-sets      PatternSets
+   ;; the index of the next update to process (note that to get the offset
+   ;; of the corresponding InventoryChange record in the :updates vector, you
+   ;; must substract the broker database's :first-update-index from this value)
+   :next-update-index s/Int})
+
+(def Inventory
+  {p/Uri Connection})
+
+(def BrokerDatabase
+  {:inventory          Inventory
+   ;; the index of the first InventoryChange record in the :updates vector
+   ;; (note that this index can overflow)
+   :first-update-index s/Int
+   :updates            [p/InventoryChange]
+   :subscriptions      {p/Uri Subscription}})
+
+(def Broker
+  {:broker-name         (s/maybe s/Str)
+   :authorization-check IFn
+   :database            (s/atom BrokerDatabase)
+   :should-stop         Object                              ;; Promise used to signal the inventory updates should stop
+   :metrics-registry    Object
+   :metrics             {s/Keyword Object}
+   :state               (s/atom BrokerState)})
+
+(s/defn get-connection :- (s/maybe Connection)
+  [broker :- Broker uri :- p/Uri]
+  (-> broker :database deref :inventory (get uri)))
+
+(s/defn build-and-register-metrics :- {s/Keyword Object}
+  [broker :- Broker]
+  (let [registry (:metrics-registry broker)]
+    (gauges/gauge-fn registry ["puppetlabs.pcp.connections"]
+                     (fn [] (-> broker :database deref :inventory count)))
+    {:on-connect       (.timer registry "puppetlabs.pcp.on-connect")
+     :on-close         (.timer registry "puppetlabs.pcp.on-close")
+     :on-message       (.timer registry "puppetlabs.pcp.on-message")
+     :on-send          (.timer registry "puppetlabs.pcp.on-send")}))
+
+;;
+;; Message sending
+;;
+
+(def MessageLog
+  "Schema for a loggable summary of a message"
+  {:messageid p/MessageId
+   :source s/Str
+   :messagetype s/Str
+   :destination p/Uri})
+
+(s/defn summarize :- MessageLog
+  [message :- Message]
+  {:messageid (:id message)
+   :messagetype (:message_type message)
+   :source (:sender message)
+   :destination (:target message)})
+
+(s/defn send-message
+  [connection :- Connection
+   message :- Message]
+  (sl/maplog :trace {:type :outgoing-message-trace
+                     :uri (ws->uri (:websocket connection))
+                     :rawmsg message}
+             (i18n/trs "Sending PCP message to '{uri}': '{rawmsg}'"))
+  (websockets-client/send! (:websocket connection)
+                           ((get-in connection [:codec :encode]) message))
+  nil)
+
+(s/defn send-error-message
+  [in-reply-to-message :- (s/maybe Message)
+   description :- s/Str
+   connection :- Connection]
+  (let [error-msg (cond-> (message/make-message
+                            {:message_type "http://puppetlabs.com/error_message"
+                             :sender "pcp:///server"
+                             :data description})
+                          in-reply-to-message (assoc :in_reply_to (:id in-reply-to-message)))]
+    (try
+      (send-message connection error-msg)
+      (catch Exception e
+        (sl/maplog :debug e
+                   {:type :message-delivery-error}
+                   (i18n/trs "Error in send-error-message"))))))
+
+(s/defn log-delivery-failure
+  "Log message delivery failure given the message and failure reason."
+  [message :- Message reason :- s/Str]
+  (sl/maplog :trace (assoc (summarize message)
+                      :type :message-delivery-failure
+                      :reason reason)
+             (i18n/trs "Failed to deliver '{messageid}' for '{destination}': '{reason}'"))
+  nil)                                                      ;; ensure nil is returned
+
+(s/defn handle-delivery-failure
+  "Send an error message with the specified description."
+  [message :- Message sender :- (s/maybe Connection) reason :- s/Str]
+  (log-delivery-failure message reason)
+  (send-error-message message reason sender))
+
+(s/defn deliver-message
+  "Message consumer. Delivers a message to the websocket indicated by the :target field"
+  [broker :- Broker
+   message :- Message
+   sender :- (s/maybe Connection)]
+  (assert (not (multicast-message? message)))
+  (if-let [connection (get-connection broker (:target message))]
+    (try
+      (sl/maplog
+        :debug (merge (summarize message)
+                      (connection/summarize connection)
+                      {:type :message-delivery})
+        (i18n/trs "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"))
+      (locking (:websocket connection)
+        (time! (:on-send (:metrics broker))
+               (send-message connection message)))
+      (catch Exception e
+        (sl/maplog :error e
+                   {:type :message-delivery-error}
+                   (i18n/trs "Error in deliver-message"))
+        (handle-delivery-failure message sender (str e))))
+    (handle-delivery-failure message sender (i18n/trs "not connected"))))
+
+(s/defn deliver-server-message
+  "Message consumer. Delivers a message to the websocket indicated by the :target field but only if it still
+  routed to the conection specified by the client argument"
+  [broker :- Broker
+   message :- Message
+   client :- Connection]
+  (assert (not (multicast-message? message)))
+  (let [connection (get-connection broker (:target message))
+        message (assoc message :sender "pcp:///server")]
+    (if (identical? connection client)
+      (try
+        (sl/maplog
+          :debug (merge (summarize message)
+                        (connection/summarize connection)
+                        {:type :message-delivery})
+          (i18n/trs "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"))
+        (locking (:websocket connection)
+          (time! (:on-send (:metrics broker))
+                 (send-message connection message))
+          true)
+        (catch Exception e
+          (sl/maplog :error e
+                     {:type :message-delivery-error}
+                     (i18n/trs "Error in deliver-message"))
+          (log-delivery-failure message (str e))))
+      (log-delivery-failure message (i18n/trs "client no longer connected")))))

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -370,6 +370,100 @@
                    (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
                    (is (= [] (:uris data))))))))
 
+(deftest inventory-node-recieves-updates-when-inventory-changes-when-subscribed-to-updates
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+               (with-open [client (client/connect :certname "client01.example.com"
+                                                  :version version)]
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client01.example.com/agent"
+                                  :data {:query ["pcp://client02.example.com/agent"]
+                                         :subscribe true}})]
+                   (client/send! client request))
+                 (let [response (client/recv! client)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= [] (:uris data))))
+                 (with-open [client2 (client/connect :certname "client02.example.com"
+                                                    :version version)]
+                   (let [response (client/recv! client)
+                         data (client/get-data response version)]
+                     (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                     (is (= [{:client "pcp://client02.example.com/agent" :change 1}] (:changes data)))))
+                 (let [response (client/recv! client)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client02.example.com/agent" :change -1}] (:changes data))))))))
+
+(deftest inventory-updates-are-properly-filtered
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+               (with-open [client1 (client/connect :certname "client01.example.com"
+                                                   :version version)
+                           client2 (client/connect :certname "client02.example.com"
+                                                   :version version)]
+                 ;; subscribe client1 for updates with a specific filter
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client01.example.com/agent"
+                                  :data {:query ["pcp://client04.example.com/*"]
+                                         :subscribe true}})]
+                   (client/send! client1 request))
+                 (let [response (client/recv! client1)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= [] (:uris data))))
+
+                 ;; subscribe client2 for updates with a match all filter
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client02.example.com/agent"
+                                  :data {:query ["pcp://*/agent"]
+                                         :subscribe true}})]
+                   (client/send! client2 request))
+                 (let [response (client/recv! client2)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= ["pcp://client01.example.com/agent" "pcp://client02.example.com/agent"] (:uris data))))
+
+                 ;; now connect a client matching only the filter client2 used for subscribing
+                 (with-open [client3 (client/connect :certname "client03.example.com"
+                                                     :version version)]
+                   (let [response (client/recv! client2)
+                         data (client/get-data response version)]
+                     (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                     (is (= [{:client "pcp://client03.example.com/agent" :change 1}] (:changes data))))
+                   ;; client1 doesn't receive an update at all, becuase the change doesn't match its filter
+                   (let [response (client/recv! client1 3000)]
+                     (is (nil? response)))
+                   (with-open [client4 (client/connect :certname "client04.example.com"
+                                                       :version version)]
+                     (let [response (client/recv! client2)
+                           data (client/get-data response version)]
+                       (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                       (is (= [{:client "pcp://client04.example.com/agent" :change 1}] (:changes data))))
+                     (let [response (client/recv! client1)
+                           data (client/get-data response version)]
+                       (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                       (is (= [{:client "pcp://client04.example.com/agent" :change 1}] (:changes data))))))
+                 ;; client4 & client3 have disconnected (in that order)
+                 (let [response (client/recv! client2)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client04.example.com/agent" :change -1}
+                           {:client "pcp://client03.example.com/agent" :change -1}] (:changes data))))
+                 (let [response (client/recv! client1)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client04.example.com/agent" :change -1}] (:changes data))))))))
+
 (def no-inventory-broker-config
   "A broker that allows connections but no inventory requests"
   (assoc-in broker-config [:authorization :rules]

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -1,40 +1,22 @@
 (ns puppetlabs.pcp.broker.core-test
   (:require [clojure.test :refer :all]
             [metrics.core]
-            [puppetlabs.pcp.testutils.client :as client]
             [puppetlabs.pcp.testutils :refer [dotestseq]]
+            [puppetlabs.pcp.broker.shared :refer [Broker]]
             [puppetlabs.pcp.broker.core :refer :all]
             [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
             [puppetlabs.pcp.broker.websocket :refer [ws->uri]]
             [puppetlabs.pcp.broker.message :as message]
-            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.pcp.broker.shared-test :refer [mock-uri mock-ws->uri make-test-broker dummy-connection-from]]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty9-core]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-config :as jetty9-config]
             [schema.core :as s]
-            [schema.test :as st]
             [slingshot.test])
-  (:import [puppetlabs.pcp.broker.connection Connection]
-           [java.util.concurrent ConcurrentHashMap]))
-
-(s/defn make-test-broker :- Broker
-  "Return a minimal clean broker state"
-  []
-  (let [broker {:broker-name         nil
-                :authorization-check (constantly true)
-                :inventory           (ConcurrentHashMap.)
-                :metrics-registry    metrics.core/default-registry
-                :metrics             {}
-                :state               (atom :running)}
-        metrics (build-and-register-metrics broker)
-        broker (assoc broker :metrics metrics)]
-    broker))
+  (:import [puppetlabs.pcp.broker.connection Connection]))
 
 (s/def identity-codec :- Codec
   {:encode identity
    :decode identity})
-
-(def mock-uri "pcp://foo.com/agent")
-(defn mock-ws->uri [ws] mock-uri)
 
 (s/defn make-mock-ssl-context-factory :- org.eclipse.jetty.util.ssl.SslContextFactory
   "Return an instance of the SslContextFactory with only a minimal configuration
@@ -87,43 +69,17 @@
     (with-redefs [ws->uri mock-ws->uri]
       (let [broker (make-test-broker)]
         (add-connection! broker (connection/make-connection :dummy-ws identity-codec))
-        (is (s/validate Connection (get (:inventory broker) mock-uri)))))))
+        (is (s/validate Connection (-> broker :database deref :inventory (get mock-uri))))))))
 
 (deftest remove-connecton-test
   (testing "It should remove a connection from the inventory map"
     (with-redefs [ws->uri mock-ws->uri]
-      (let [broker (make-test-broker)]
-        (.put (:inventory broker)
-              mock-uri (connection/make-connection :dummy-ws identity-codec))
-        (is (not= {} (:inventory broker)))
+      (let [broker (make-test-broker)
+            connection (connection/make-connection :dummy-ws identity-codec)]
+        (swap! (:database broker) update :inventory assoc mock-uri connection)
+        (is (not= {} (-> broker :database deref :inventory)))
         (remove-connection! broker mock-uri)
-        (is (= {} (:inventory broker)))))))
-
-(deftest handle-delivery-failure-test
-  (let [broker (make-test-broker)
-        msg (message/make-message)
-        delivered (atom [])]
-    (with-redefs [puppetlabs.pcp.broker.core/send-error-message
-                  (fn [mg reason sender]
-                    (swap! delivered conj mg))]
-      (testing "redelivery always"
-        (handle-delivery-failure msg nil "Out of cheese")
-        (is (= 1 (count @delivered)))))))
-
-(deftest deliver-message-test
-  (let [broker (make-test-broker)
-        failure (atom nil)]
-    (testing "delivers messages"
-      (let [message (message/make-message
-                     {:target "pcp://example01.example.com/foo"})]
-        (with-redefs [puppetlabs.pcp.broker.core/handle-delivery-failure
-                      (fn [message sender err] (reset! failure err))]
-          (deliver-message broker message nil)
-          (is (= "not connected" @failure)))))
-    (testing "errors if multicast message"
-      (let [message (message/make-message)]
-        (with-redefs [puppetlabs.pcp.broker.message/multicast-message?  (fn [message] true)]
-          (is (thrown? java.lang.AssertionError (deliver-message broker message nil))))))))
+        (is (= {} (-> broker :database deref :inventory)))))))
 
 (deftest make-ring-request-test
   (testing "it should return a ring request - one target"
@@ -184,17 +140,17 @@
   (let [closed (atom (promise))]
     (with-redefs [puppetlabs.experimental.websockets.client/close! (fn [& args] (deliver @closed args))
                   puppetlabs.experimental.websockets.client/send! (constantly false)
-                  puppetlabs.pcp.broker.websocket/ws->client-type (fn [ws] "controller")
-                  ws->uri (fn [ws] "pcp://localhost/controller")]
+                  puppetlabs.pcp.broker.websocket/ws->client-type (fn [_] "controller")
+                  ws->uri (fn [_] "pcp://localhost/controller")]
       (let [message (-> (message/make-message
                          {:sender "pcp://localhost/controller"
                           :message_type "http://puppetlabs.com/login_message"}))]
         (testing "It should return an associated Connection if there's no reason to deny association"
           (reset! closed (promise))
           (let [broker     (make-test-broker)
-                connection-uri (->> (add-connection! broker (connection/make-connection :dummy-ws identity-codec))
-                                    (process-associate-request! broker message)
-                                    :uri)]
+                connection (connection/make-connection :dummy-ws identity-codec)
+                _ (add-connection! broker connection)
+                connection-uri (:uri (process-associate-request! broker message connection))]
             (is (not (realized? @closed)))
             (is (= "pcp://localhost/controller" connection-uri))))))))
 
@@ -207,8 +163,8 @@
         connection (connection/make-connection :dummy-ws identity-codec)
         accepted (atom nil)]
     (with-redefs
-     [puppetlabs.pcp.broker.core/deliver-message (fn [broker message connection]
-                                                   (reset! accepted message))]
+     [puppetlabs.pcp.broker.shared/deliver-server-message (fn [_ message _]
+                                                            (reset! accepted message))]
       (let [outcome (process-inventory-request broker message connection)]
         (is (nil? outcome))
         (is (= [] (:uris (:data @accepted))))))))
@@ -221,16 +177,11 @@
           connection (connection/make-connection :dummy-ws identity-codec)
           associate-request (atom nil)]
       (with-redefs
-       [puppetlabs.pcp.broker.core/process-associate-request! (fn [broker message connection]
+       [puppetlabs.pcp.broker.core/process-associate-request! (fn [_ message connection]
                                                                 (reset! associate-request message)
                                                                 connection)]
         (process-server-message! broker message connection)
         (is (not= nil @associate-request))))))
-
-(s/defn dummy-connection-from :- Connection
-  [common-name]
-  (assoc (connection/make-connection :dummy-ws message/v2-codec)
-         :common-name common-name))
 
 (deftest authenticated?-test
   (with-redefs [ws->uri mock-ws->uri]
@@ -286,7 +237,7 @@
                     :message_type "http://puppetlabs.com/associate_request"})
               connection (dummy-connection-from "localcost")
               is-association-request true]
-          (with-redefs [puppetlabs.pcp.broker.message/multicast-message?  (fn [message] true)]
+          (with-redefs [puppetlabs.pcp.broker.message/multicast-message?  (fn [_] true)]
             (is (= :multicast-unsupported
                    (validate-message yes-broker msg connection is-association-request))))))
       (testing "marks expired messages as to be processed"
@@ -309,35 +260,6 @@
           (is (= :to-be-processed
                  (validate-message yes-broker msg connection is-association-request))))))))
 
-(deftest send-error-message-test
-  (with-redefs [ws->uri mock-ws->uri]
-    (let [error-msg (atom nil)
-          connection (dummy-connection-from "host_x")]
-      (with-redefs [puppetlabs.experimental.websockets.client/send!
-                    (fn [websocket raw-message]
-                      (reset! error-msg (message/v2-decode raw-message)))]
-        (testing "sends error_message correctly and returns nil if received msg is NOT given"
-          (let [received-msg nil
-                error-description "something wrong!"
-                outcome (send-error-message received-msg error-description connection)
-                msg-data (:data @error-msg)]
-            (is (nil? outcome))
-            (is (not (contains? @error-msg :in_reply_to)))
-            (is (= error-description msg-data))))
-        (testing "sends error_message correctly and returns nil if received msg is given"
-          (reset! error-msg nil)
-          (let [the-uuid (ks/uuid)
-                received-msg (message/make-message
-                              {:sender "pcp://test_example/pcp_client_alpha"
-                               :message_type "gossip"
-                               :target "pcp://test_broker/server"})
-                received-msg (assoc received-msg :id the-uuid)
-                error-description "something really wrong :o"
-                outcome (send-error-message received-msg error-description connection)
-                msg-data (:data @error-msg)]
-            (is (nil? outcome))
-            (is (= the-uuid (:in_reply_to @error-msg)))
-            (is (= error-description msg-data))))))))
 
 (deftest process-message-test
   (with-redefs [puppetlabs.pcp.broker.core/make-ring-request make-valid-ring-request
@@ -351,11 +273,11 @@
                       :message_type "some_kinda_love"
                       :target "pcp://host_b/entity"}))
             connection (dummy-connection-from "host_a")]
-        (.put (:inventory broker) "pcp://host_a/entity" connection)
-        (with-redefs [puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] connection)
-                      puppetlabs.pcp.broker.core/deliver-message
-                      (fn [broker message connection]
+        (swap! (:database broker) update :inventory assoc "pcp://host_a/entity" connection)
+        (with-redefs [puppetlabs.pcp.broker.shared/get-connection
+                      (fn [_ _] connection)
+                      puppetlabs.pcp.broker.shared/deliver-message
+                      (fn [_ _ _]
                         (reset! called-accept-message true) nil)
                       ws->uri mock-ws->uri]
           (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
@@ -370,10 +292,10 @@
                       :target "pcp://gangoffour/entity"}))
             connection (dummy-connection-from "wire")]
         (with-redefs [ws->uri mock-ws->uri
-                      puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] connection)
-                      puppetlabs.pcp.broker.core/send-error-message
-                      (fn [msg description connection]
+                      puppetlabs.pcp.broker.shared/get-connection
+                      (fn [_ _] connection)
+                      puppetlabs.pcp.broker.shared/send-error-message
+                      (fn [_ description _]
                         (reset! error-message-description description) nil)]
           (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
             (is (= "Message not authenticated" @error-message-description))
@@ -388,10 +310,10 @@
                   :target "pcp://fourtet/entity"})
             connection (dummy-connection-from "thegunclub")]
         (with-redefs [ws->uri mock-ws->uri
-                      puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] connection)
-                      puppetlabs.pcp.broker.core/send-error-message
-                      (fn [msg description connection]
+                      puppetlabs.pcp.broker.shared/get-connection
+                      (fn [_ _] connection)
+                      puppetlabs.pcp.broker.shared/send-error-message
+                      (fn [_ description _]
                         (reset! error-message-description description) nil)]
           (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
             (is (= "Message not authorized" @error-message-description))
@@ -405,10 +327,10 @@
                   :message_type "jackonfire"
                   :target "pcp:///server"})
             connection (dummy-connection-from "thegunclub")]
-        (with-redefs [puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] connection)
+        (with-redefs [puppetlabs.pcp.broker.shared/get-connection
+                      (fn [_ _] connection)
                       puppetlabs.pcp.broker.core/process-server-message!
-                      (fn [broker message connection]
+                      (fn [_ _ _]
                         (reset! processed-server-message true) nil)
                       ws->uri mock-ws->uri]
           (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
@@ -424,10 +346,10 @@
                   :target "pcp://wire/*"})
             connection (dummy-connection-from "thegunclub")]
         (with-redefs [ws->uri mock-ws->uri
-                      puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] connection)
-                      puppetlabs.pcp.broker.core/send-error-message
-                      (fn [msg description connection]
+                      puppetlabs.pcp.broker.shared/get-connection
+                      (fn [_ _] connection)
+                      puppetlabs.pcp.broker.shared/send-error-message
+                      (fn [_ description _]
                         (reset! error-message-description description) nil)]
           (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
             (is (= "Multiple recipients no longer supported" @error-message-description))
@@ -442,10 +364,10 @@
                   :target "pcp://wire/entity"})
             connection (dummy-connection-from "gangoffour")]
         (with-redefs [ws->uri mock-ws->uri
-                      puppetlabs.pcp.broker.core/get-connection
-                      (fn [broker ws] connection)
-                      puppetlabs.pcp.broker.core/deliver-message
-                      (fn [broker message connection]
+                      puppetlabs.pcp.broker.shared/get-connection
+                      (fn [_ _] connection)
+                      puppetlabs.pcp.broker.shared/deliver-message
+                      (fn [_ _ _]
                         (reset! accepted-message-for-delivery true) nil)]
           (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
             (is @accepted-message-for-delivery)
@@ -464,10 +386,10 @@
                             :common-name "gangoffour")]
       (with-redefs [puppetlabs.pcp.broker.core/make-ring-request make-valid-ring-request
                     ws->uri mock-ws->uri
-                    puppetlabs.pcp.broker.core/get-connection
-                    (fn [broker ws] connection)
+                    puppetlabs.pcp.broker.shared/get-connection
+                    (fn [_ _] connection)
                     puppetlabs.experimental.websockets.client/send!
-                    (fn [websocket message] (reset! sent-message message))]
+                    (fn [_ message] (reset! sent-message message))]
         (let [outcome (process-message! broker (message/v1-encode msg) :dummy-ws)]
           (is (= msg (message/v1-decode @sent-message)))
           (is (nil? outcome))))))
@@ -483,10 +405,10 @@
                             :common-name "gangoffour")]
       (with-redefs [puppetlabs.pcp.broker.core/make-ring-request make-valid-ring-request
                     ws->uri mock-ws->uri
-                    puppetlabs.pcp.broker.core/get-connection
-                    (fn [broker ws] connection)
+                    puppetlabs.pcp.broker.shared/get-connection
+                    (fn [_ _] connection)
                     puppetlabs.experimental.websockets.client/send!
-                    (fn [websocket message] (reset! sent-message message))]
+                    (fn [_ message] (reset! sent-message message))]
         (let [outcome (process-message! broker (message/v2-encode msg) :dummy-ws)]
           (is (= msg (message/v2-decode @sent-message)))
           (is (nil? outcome)))))))

--- a/test/unit/puppetlabs/pcp/broker/message_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/message_test.clj
@@ -1,29 +1,29 @@
-(ns puppetlabs.pcp.broker.core-test
+(ns puppetlabs.pcp.broker.message-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.broker.message :as message]))
+            [puppetlabs.pcp.broker.message :refer :all]))
 
 (deftest multicast-message?-test
   (testing "returns false if target specifies a single host with no wildcards"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:target "pcp://example01.example.com/foo"})]
       (is (not (multicast-message? message)))))
   (testing "returns true if target includes wildcard hostname"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:target "pcp://*/foo"})]
       (is (multicast-message? message))))
   (testing "returns true if target includes wildcard client type"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:target "pcp://example01.example.com/*"})]
       (is (multicast-message? message))))
   (testing "returns true if multicast-message key is inserted"
-    (let [message (message/make-message
-                   {:target "pcp://example01.example.com/agent"
-                    :multicast-message true})]
+    (let [message (-> (make-message
+                       {:target "pcp://example01.example.com/agent"})
+                      (assoc :multicast-message true))]
       (is (multicast-message? message)))))
 
 (deftest message-roundtrip-test
   (testing "message survives v1 roundtrip"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:sender "pcp://gangoffour/entity"
                     :message_type "ether"
                     :target "pcp://gangoffour/entity"})]
@@ -31,7 +31,7 @@
                          v1-encode
                          v1-decode)))))
   (testing "message survives v2 roundtrip"
-    (let [message (message/make-message
+    (let [message (make-message
                    {:sender "pcp://gangoffour/entity"
                     :message_type "ether"
                     :target "pcp://gangoffour/entity"})]

--- a/test/unit/puppetlabs/pcp/broker/shared_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/shared_test.clj
@@ -1,0 +1,91 @@
+(ns puppetlabs.pcp.broker.shared-test
+  (:require [clojure.test :refer :all]
+            [metrics.core]
+            [puppetlabs.pcp.testutils :refer [dotestseq]]
+            [puppetlabs.pcp.broker.shared :refer :all]
+            [puppetlabs.pcp.broker.connection :as connection :refer [Codec]]
+            [puppetlabs.pcp.broker.inventory :as inventory]
+            [puppetlabs.pcp.broker.websocket :refer [ws->uri]]
+            [puppetlabs.pcp.broker.message :as message]
+            [puppetlabs.kitchensink.core :as ks]
+            [schema.core :as s]
+            [slingshot.test])
+  (:import [puppetlabs.pcp.broker.connection Connection]))
+
+(def mock-uri "pcp://foo.com/agent")
+(defn mock-ws->uri [_] mock-uri)
+
+(s/defn dummy-connection-from :- Connection
+  [common-name]
+  (assoc (connection/make-connection :dummy-ws message/v2-codec)
+    :common-name common-name))
+
+(s/defn make-test-broker :- Broker
+  "Return a minimal clean broker state"
+  []
+  (let [broker {:broker-name         nil
+                :authorization-check (constantly true)
+                :database            (atom (inventory/init-database))
+                :should-stop         (promise)
+                :metrics             {}
+                :metrics-registry    metrics.core/default-registry
+                :state               (atom :running)}
+        metrics (build-and-register-metrics broker)
+        broker (assoc broker :metrics metrics)]
+    broker))
+
+(deftest handle-delivery-failure-test
+  (let [_ (make-test-broker)
+        msg (message/make-message)
+        delivered (atom [])]
+    (with-redefs [puppetlabs.pcp.broker.shared/send-error-message
+                  (fn [mg _ _]
+                    (swap! delivered conj mg))]
+      (testing "redelivery always"
+        (handle-delivery-failure msg nil "Out of cheese")
+        (is (= 1 (count @delivered)))))))
+
+(deftest deliver-message-test
+  (let [broker (make-test-broker)
+        failure (atom nil)]
+    (testing "delivers messages"
+      (let [message (message/make-message
+                     {:target "pcp://example01.example.com/foo"})]
+        (with-redefs [puppetlabs.pcp.broker.shared/handle-delivery-failure
+                      (fn [_ _ err] (reset! failure err))]
+          (deliver-message broker message nil)
+          (is (= "not connected" @failure)))))
+    (testing "errors if multicast message"
+      (let [message (message/make-message)]
+        (with-redefs [puppetlabs.pcp.broker.message/multicast-message?  (fn [_] true)]
+          (is (thrown? java.lang.AssertionError (deliver-message broker message nil))))))))
+
+(deftest send-error-message-test
+  (with-redefs [ws->uri mock-ws->uri]
+    (let [error-msg (atom nil)
+          connection (dummy-connection-from "host_x")]
+      (with-redefs [puppetlabs.experimental.websockets.client/send!
+                    (fn [_ raw-message]
+                      (reset! error-msg (message/v2-decode raw-message)))]
+        (testing "sends error_message correctly and returns nil if received msg is NOT given"
+          (let [received-msg nil
+                error-description "something wrong!"
+                outcome (send-error-message received-msg error-description connection)
+                msg-data (:data @error-msg)]
+            (is (nil? outcome))
+            (is (not (contains? @error-msg :in_reply_to)))
+            (is (= error-description msg-data))))
+        (testing "sends error_message correctly and returns nil if received msg is given"
+          (reset! error-msg nil)
+          (let [the-uuid (ks/uuid)
+                received-msg (message/make-message
+                              {:sender "pcp://test_example/pcp_client_alpha"
+                               :message_type "gossip"
+                               :target "pcp://test_broker/server"})
+                received-msg (assoc received-msg :id the-uuid)
+                error-description "something really wrong :o"
+                outcome (send-error-message received-msg error-description connection)
+                msg-data (:data @error-msg)]
+            (is (nil? outcome))
+            (is (= the-uuid (:in_reply_to @error-msg)))
+            (is (= error-description msg-data))))))))


### PR DESCRIPTION
This PR introduces support for inventory updates. To be able to support the updates the `:inventory` map has been replaced with a more complex `:database` map which includes:
- `:inventory`, the original inventory mapping of a client Uri to a websocket connection
- `:updates`, a vector of updates (a vector of inventory change records)
- `:first-update-index`, the index of the first update in the `:updates` vector, this is an ever increasing (and overflowing index) which is increased when entries are removed from the beginning of the `:updates` vector
- `:subscriptions`, mapping of an Uri of a client which subscribed to inventory updates to a subscription record

Each subscription record consists of:
- `:connection`, the websocket connection on which the subscription was received, this is used to detect stale subscriptions
- `:pattern-sets`, a form of Uri filters of the inventory updates the subscriber is interested in receiving
- `:next-update-index`, the index of the next update that should be sent to the subscriber (provided that it matches the :pattern-sets)

The operation:
- when a client connects/disconnects a mapping is added to/removed from the `:inventory` map in the `:database` (if the client is subscribed to the inventory updates on disconnect, it is unsubscribed - removed from the `:subscriptions` map) and an appropriate inventory change record is added to the `:updates` vector
- when an inventory request is received a snapshot of the broker database is obtained while subscribing or unsubscribing the client to inventory updates (adding the client to/removing the the client from the `:subscriptions` map) depending on the `:subscribe` flag in the inventory request, then the `:inventory` from the database snapshot is used to build the inventory response
- updates are sent periodically to subscribed clients; on each iteration a snapshot of the broker database is obtained, then for each subscribed client as per the :subscriptions map in the broker database snapshot the following is performed in a `swap!` call (which purpose is to update the subscription in the broker database):
  - first a check is made whether the subscription from the snapshot is identical to the current subscription, if it's not then the subscription is ignored in this iteration
  - then a check is made whether the update has already been sent (there is an atom outside of the swap! call tracking this information), if it has not then the update message is built and a delivery of the message is attempted; then the atom is updated to indicate the message has been sent
  - finally a new version of the broker database is constructed where the subscription's `:next-update-index` is updated accordingly; this version of the database is returned to the `swap!` call; if the swap doesn't succeed the process is repeated
- after updates are sent to all subscribed clients, processed inventory change records (records which have successfully been sent in inventory updates to all subscribed clients) are removed from the broker database's `:updates` vector and the `:first-update-index` is increased accordingly