### PR TITLE
(PCP-707, PCP-600) Add stress test for subscriptions, fix race that sends inventory update before response

### DIFF
--- a/src/puppetlabs/pcp/broker/inventory.clj
+++ b/src/puppetlabs/pcp/broker/inventory.clj
@@ -159,6 +159,8 @@
            (-> database-snapshot :subscriptions keys))
          (remove-processed-updates broker))))
 
+(def batch-update-interval-ms 1000)
+
 (s/defn start-inventory-updates!
   "Start periodic sending of the inventory updates."
   [broker :- Broker]
@@ -166,7 +168,7 @@
     (let [should-stop (:should-stop broker)]
       (loop []
         (send-updates broker)
-        (if (nil? (deref should-stop 1000 nil))
+        (if (nil? (deref should-stop batch-update-interval-ms nil))
           (recur))))))
 
 (s/defn stop-inventory-updates!

--- a/src/puppetlabs/pcp/broker/inventory.clj
+++ b/src/puppetlabs/pcp/broker/inventory.clj
@@ -85,9 +85,10 @@
           {:changes filtered})))
 
 (s/defn subscribe-client! :- shared/BrokerDatabase
-  "Subscribe the specified client for inventory updates. Return the broker database snapshot
-  at the time of subscribing."
-  [broker :- Broker client :- p/Uri connection :- Connection pattern-sets :- shared/PatternSets]
+  "Subscribe the specified client for inventory updates. Expects a promise of a connection, to be
+  fulfilled when the initial inventory response has been sent; that prevents messages appearing out
+  of order. Return the broker database snapshot at the time of subscribing."
+  [broker :- Broker client :- p/Uri connection :- Object pattern-sets :- shared/PatternSets]
   (let [database (:database broker)]
     (swap! database
            #(update % :subscriptions assoc client {:connection        connection
@@ -133,13 +134,14 @@
                               (if (nil? @processed-count-atom) ;; have we not sent the update to this subscriber yet?
                                 (let [data (-> (subvec updates next-update-offset) ;; skip updates which have already been sent to this subscriber
                                                (build-update-data (:pattern-sets subscription)))]
-                                  (if (or (nil? data) ;; there are no updates for this subscriber
-                                          (deliver-server-message broker
-                                                                  (message/make-message
-                                                                    {:message_type "http://puppetlabs.com/inventory_update"
-                                                                     :target subscriber
-                                                                     :data data})
-                                                                  (:connection subscription)))
+                                  (if (and (realized? (:connection subscription)) ;; prevent update before inventory response
+                                           (or (nil? data) ;; there are no updates for this subscriber
+                                               (deliver-server-message broker
+                                                                       (message/make-message
+                                                                         {:message_type "http://puppetlabs.com/inventory_update"
+                                                                          :target subscriber
+                                                                          :data data})
+                                                                       @(:connection subscription))))
                                     (reset! processed-count-atom updates-count)
                                     (reset! processed-count-atom next-update-offset))))
                               (let [processed-count @processed-count-atom]

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -7,7 +7,10 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty9-core]
             [puppetlabs.i18n.core :as i18n]))
 
+(defprotocol BrokerService)
+
 (trapperkeeper/defservice broker-service
+  BrokerService
   [[:AuthorizationService authorization-check]
    [:ConfigService get-in-config]
    [:WebroutingService add-websocket-handler get-server get-route]

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -20,7 +20,9 @@
   {:explicit #{p/Uri} :wildcard #{p/ExplodedUri}})
 
 (def Subscription
-  {:connection        Connection
+  {;; Promise that resolves to the Connection after inventory response has been
+   ;; sent. This ensures no updates are sent before the initial response.
+   :connection        Object
    :pattern-sets      PatternSets
    ;; the index of the next update to process (note that to get the offset
    ;; of the corresponding InventoryChange record in the :updates vector, you

--- a/test/integration/puppetlabs/pcp/broker/subscription_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/subscription_test.clj
@@ -23,7 +23,7 @@
                    (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
                    (is (= [] (:uris data))))
                  (with-open [client2 (client/connect :certname "client02.example.com"
-                                                    :version version)]
+                                                     :version version)]
                    (let [response (client/recv! client)
                          data (client/get-data response version)]
                      (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
@@ -33,7 +33,7 @@
                    (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
                    (is (= [{:client "pcp://client02.example.com/agent" :change -1}] (:changes data))))))))
 
-(deftest inventory-updates-are-properly-filtered
+(deftest inventory-updates-are-properly-filtered-and-batched
   (with-app-with-config app broker-services broker-config
     (dotestseq [version protocol-versions]
                (with-open [client1 (client/connect :certname "client01.example.com"
@@ -98,3 +98,63 @@
                        data (client/get-data response version)]
                    (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
                    (is (= [{:client "pcp://client04.example.com/agent" :change -1}] (:changes data))))))))
+
+(def inventory-subscribe
+  (client/make-message
+    {:message_type "http://puppetlabs.com/inventory_request"
+     :data {:query ["pcp://client01.example.com/*"] :subscribe true}}))
+
+(defn initial-inventory
+  [controller]
+  (client/send! controller inventory-subscribe)
+  (let [response (client/recv! controller)
+        data (client/get-data response)]
+    (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+    (is (vector? (:uris data)))
+    (:uris data)))
+
+(defn process-update
+  [controller initial-connections]
+  (let [update (client/recv! controller)
+        data (client/get-data update)]
+    (is (= "http://puppetlabs.com/inventory_update" (:message_type update)))
+    (loop [changes (:changes data)
+           connections initial-connections]
+      (if-let [{:keys [change client]} (first changes)]
+        (if (pos? change)
+          (do (is (not (contains? connections client)))
+              (recur (rest changes) (conj connections client)))
+          (do (is (contains? connections client))
+              (recur (rest changes) (disj connections client))))
+        connections))))
+
+(defn process-updates-until
+  ([goal controller] (process-updates-until goal controller (set (initial-inventory controller))))
+  ([goal controller initial-connections]
+   (loop [connections initial-connections]
+     (if (not= (count connections) goal)
+       (recur (process-update controller connections))
+       connections))))
+
+;; Going much above this triggers errors creating new native threads on my laptop.
+(def client-count 30)
+
+(deftest inventory-race-detector
+  (with-redefs [puppetlabs.pcp.broker.inventory/batch-update-interval-ms 10]
+    (with-app-with-config app broker-services broker-config
+      ;; Start connecting agents, and at the same time connect a controller and subscribe to updates.
+      ;; Ensure final inventory includes all connections.
+      (let [uris (set (map #(str "pcp://client01.example.com/" %) (range client-count)))
+            agents (doall (map (fn [i] (future (Thread/sleep (+ 200 (rand-int 1000)))  ;; use a sleep to try to let controllers connect
+                                               (client/connect :certname "client01.example.com" :type (str i))))
+                               (range client-count)))]
+        (with-open [controller1 (client/connect :certname "controller01.example.com")
+                    controller2 (client/connect :certname "controller02.example.com")]
+          (let [controllers [controller1 controller2]
+                connections (pmap (partial process-updates-until client-count) controllers)]
+            (is (every? #(= uris %) connections))
+
+            ;; Disconnect clients and ensure inventory empties.
+            (doseq [c agents] (.close @c))
+            (let [final-connections (pmap (partial process-updates-until 0) controllers connections)]
+              (is (every? empty? final-connections)))))))))

--- a/test/integration/puppetlabs/pcp/broker/subscription_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/subscription_test.clj
@@ -1,0 +1,100 @@
+(ns puppetlabs.pcp.broker.subscription-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.pcp.testutils :refer [dotestseq]]
+            [puppetlabs.pcp.testutils.service :refer [broker-config protocol-versions broker-services]]
+            [puppetlabs.pcp.testutils.client :as client]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]))
+
+(deftest inventory-node-recieves-updates-when-inventory-changes-when-subscribed-to-updates
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+               (with-open [client (client/connect :certname "client01.example.com"
+                                                  :version version)]
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client01.example.com/agent"
+                                  :data {:query ["pcp://client02.example.com/agent"]
+                                         :subscribe true}})]
+                   (client/send! client request))
+                 (let [response (client/recv! client)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= [] (:uris data))))
+                 (with-open [client2 (client/connect :certname "client02.example.com"
+                                                    :version version)]
+                   (let [response (client/recv! client)
+                         data (client/get-data response version)]
+                     (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                     (is (= [{:client "pcp://client02.example.com/agent" :change 1}] (:changes data)))))
+                 (let [response (client/recv! client)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client02.example.com/agent" :change -1}] (:changes data))))))))
+
+(deftest inventory-updates-are-properly-filtered
+  (with-app-with-config app broker-services broker-config
+    (dotestseq [version protocol-versions]
+               (with-open [client1 (client/connect :certname "client01.example.com"
+                                                   :version version)
+                           client2 (client/connect :certname "client02.example.com"
+                                                   :version version)]
+                 ;; subscribe client1 for updates with a specific filter
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client01.example.com/agent"
+                                  :data {:query ["pcp://client04.example.com/*"]
+                                         :subscribe true}})]
+                   (client/send! client1 request))
+                 (let [response (client/recv! client1)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= [] (:uris data))))
+
+                 ;; subscribe client2 for updates with a match all filter
+                 (let [request (client/make-message
+                                 version
+                                 {:message_type "http://puppetlabs.com/inventory_request"
+                                  :target "pcp:///server"
+                                  :sender "pcp://client02.example.com/agent"
+                                  :data {:query ["pcp://*/agent"]
+                                         :subscribe true}})]
+                   (client/send! client2 request))
+                 (let [response (client/recv! client2)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_response" (:message_type response)))
+                   (is (= ["pcp://client01.example.com/agent" "pcp://client02.example.com/agent"] (:uris data))))
+
+                 ;; now connect a client matching only the filter client2 used for subscribing
+                 (with-open [client3 (client/connect :certname "client03.example.com"
+                                                     :version version)]
+                   (let [response (client/recv! client2)
+                         data (client/get-data response version)]
+                     (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                     (is (= [{:client "pcp://client03.example.com/agent" :change 1}] (:changes data))))
+                   ;; client1 doesn't receive an update at all, becuase the change doesn't match its filter
+                   (let [response (client/recv! client1 3000)]
+                     (is (nil? response)))
+                   (with-open [client4 (client/connect :certname "client04.example.com"
+                                                       :version version)]
+                     (let [response (client/recv! client2)
+                           data (client/get-data response version)]
+                       (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                       (is (= [{:client "pcp://client04.example.com/agent" :change 1}] (:changes data))))
+                     (let [response (client/recv! client1)
+                           data (client/get-data response version)]
+                       (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                       (is (= [{:client "pcp://client04.example.com/agent" :change 1}] (:changes data))))))
+                 ;; client4 & client3 have disconnected (in that order)
+                 (let [response (client/recv! client2)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client04.example.com/agent" :change -1}
+                           {:client "pcp://client03.example.com/agent" :change -1}] (:changes data))))
+                 (let [response (client/recv! client1)
+                       data (client/get-data response version)]
+                   (is (= "http://puppetlabs.com/inventory_update" (:message_type response)))
+                   (is (= [{:client "pcp://client04.example.com/agent" :change -1}] (:changes data))))))))

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -1,11 +1,8 @@
 (ns puppetlabs.pcp.testutils.client
   (:require [clojure.test :refer :all]
             [puppetlabs.pcp.broker.message :as message]
-            [puppetlabs.pcp.broker.connection :as connection]
-            [clojure.set :refer [rename-keys]]
             [clojure.core.async :as async :refer [timeout alts!! chan >!! <!! put!]]
             [http.async.client :as http]
-            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.pcp.message-v1 :as m1]
             [puppetlabs.pcp.message-v2 :as m2]
             [puppetlabs.ssl-utils.core :as ssl-utils]))

--- a/test/utils/puppetlabs/pcp/testutils/server.clj
+++ b/test/utils/puppetlabs/pcp/testutils/server.clj
@@ -1,6 +1,5 @@
 (ns puppetlabs.pcp.testutils.server
-  (:require [clojure.test :refer :all]
-            [puppetlabs.experimental.websockets.client :as websockets-client]
+  (:require [puppetlabs.experimental.websockets.client :as websockets-client]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]

--- a/test/utils/puppetlabs/pcp/testutils/service.clj
+++ b/test/utils/puppetlabs/pcp/testutils/service.clj
@@ -1,0 +1,45 @@
+(ns puppetlabs.pcp.testutils.service
+  (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
+            [puppetlabs.pcp.broker.service :refer [broker-service]]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
+            [puppetlabs.trapperkeeper.services.metrics.metrics-service :refer [metrics-service]]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
+            [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service]]
+            [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]))
+
+(def broker-config
+  "A broker with ssl"
+  {:authorization {:version 1
+                   :rules [{:name "allow all"
+                            :match-request {:type "regex"
+                                            :path "^/.*$"}
+                            :allow-unauthenticated true
+                            :sort-order 1}]}
+
+   :webserver {:ssl-host "127.0.0.1"
+               ;; usual port is 8142.  Here we use 58142 so if we're developing
+               ;; we can run a long-running instance and this one for the
+               ;; tests.
+               :ssl-port 58142
+               :client-auth "want"
+               :ssl-key "./test-resources/ssl/private_keys/broker.example.com.pem"
+               :ssl-cert "./test-resources/ssl/certs/broker.example.com.pem"
+               :ssl-ca-cert "./test-resources/ssl/ca/ca_crt.pem"
+               :ssl-crl-path "./test-resources/ssl/ca/ca_crl.pem"}
+
+   :web-router-service
+   {:puppetlabs.pcp.broker.service/broker-service {:v1 "/pcp/v1.0"
+                                                   :v2 "/pcp/v2.0"}
+    :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"}
+
+   :metrics {:enabled true
+             :server-id "localhost"}})
+
+(def protocol-versions
+  "The short names of versioned endpoints"
+  ["v1.0" "v2.0"])
+
+(def broker-services
+  "The trapperkeeper services the broker needs"
+  [authorization-service broker-service jetty9-service webrouting-service metrics-service status-service scheduler-service])


### PR DESCRIPTION
# (maint) Refactor integration tests

Extract common service setup into a new testutils namespace, and split
subscription tests into their own namespace.

Also removes unused library inclusion and fixes a race in finishing
`it-closes-connections-when-not-running-test`.

# (PCP-700) Add stress test for subscriptions and many connections

Adds a stress test for many connections being established as
subscriptions are initiated. Ensures inventory stays insync.

# (PCP-600) Fix race sending inventory update before requests

Normally a client requesting updates is registered as a subscriber, and
an inventory response sent. It happens in this order to ensure no
updates are missed; the reverse order would allow for an inventory
response to be sent then a change in inventory to happen before the
subscription is registered.

However, the current order allows for an inventory update to be sent by
the subscription thread between registering as a subscriber and sending
the inventory response. Use locking to ensure that subscription and
inventory response happen in sequence, preventing any updates from being
sent to the subscriber until the response has first been sent.