### PR TITLE
(PCP-712) Fix unsubscribe for controllers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "1.0.0"]
+                 [puppetlabs/pcp-client "1.1.0"]
                  [puppetlabs/pcp-common "1.1.1"]
 
                  [puppetlabs/i18n]]


### PR DESCRIPTION
Ensures controllers unsubscribe from inventory updates when they become
disconnected.

Depends on https://github.com/puppetlabs/pcp-broker/pull/168 and https://github.com/puppetlabs/clj-pcp-client/pull/71 (released in a pcp-client 1.1.0).