### PR TITLE
(PCP-701) purge clients after controller disconnections

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -86,10 +86,17 @@ of message types allowed to those connections. If the whitelist is not specified
 inventory requests are authorized. Note that all URIs must use a distinct hostname/port
 combination (the path is not taken into account when generating PCP identifiers).
 
+Users may also supply a controller disconnection graceperiod, which represents
+the amount of time to wait after all controllers become disconnected before
+evicting all client connections (to allow them to redistribute to other
+brokers). If unspecified, this defaults to 45 seconds. The parameter is
+supplied in milliseconds.
+
 ```
 pcp-broker: {
     controller-uris: ["wss://broker.example.com:8143/server", "wss://broker2.example.com:8143/server"],
     controller-whitelist: ["http://puppetlabs.com/inventory_request",
-                           "http://puppetlabs.com/rpc_blocking_request"]
+                           "http://puppetlabs.com/rpc_blocking_request"],
+    controller-disconnection-graceperiod: 45000
 }
 ```

--- a/locales/eo.po
+++ b/locales/eo.po
@@ -2,7 +2,7 @@
 # Copyright (C) YEAR Puppet <docs@puppet.com>
 # This file is distributed under the same license as the puppetlabs.pcp_broker package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -12,36 +12,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Sending PCP message to '{uri}': '{rawmsg}'"
-msgstr "[Şḗƞḓīƞɠ ƤƇƤ ḿḗşşȧɠḗ ŧǿ '{uri}': '{rawmsg}' ǲϖϱǈǋǲǅ ſſ]"
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Error in send-error-message"
-msgstr "[Ḗřřǿř īƞ şḗƞḓ-ḗřřǿř-ḿḗşşȧɠḗ ıϐſ靐靐 靐ΰ 鶱]"
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
-msgstr ""
-"[Ƒȧīŀḗḓ ŧǿ ḓḗŀīṽḗř '{messageid}' ƒǿř '{destination}': '{reason}' ΰϵẛſϵϰ ϵǅ]"
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"
-msgstr ""
-"[Ḓḗŀīṽḗřīƞɠ '{messageid}' ŧǿ '{destination}' ȧŧ '{remoteaddress}' ϕϐǲϑΐſǲΰϖ]"
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "Error in deliver-message"
-msgstr "[Ḗřřǿř īƞ ḓḗŀīṽḗř-ḿḗşşȧɠḗ ǈǲΐ靐ς ΐ靐 ΐ]"
-
-#: src/puppetlabs/pcp/broker/core.clj
-msgid "not connected"
-msgstr "[ƞǿŧ ƈǿƞƞḗƈŧḗḓ ǅϕ靐 鶱衋ǋϰſǅǈ]"
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid ""
@@ -49,8 +23,8 @@ msgid ""
 "'{remoteaddress}'. Session was already associated as '{existinguri}'"
 msgstr ""
 "[Řḗƈḗīṽḗḓ şḗşşīǿƞ ȧşşǿƈīȧŧīǿƞ ƒǿř '{uri}' ƒřǿḿ '{commonname}' "
-"'{remoteaddress}'. Şḗşşīǿƞ ẇȧş ȧŀřḗȧḓẏ ȧşşǿƈīȧŧḗḓ ȧş '{existinguri}' "
-"ǋſǈϖſ靐衋ſ ǲ靐ǋ鶱ǈǅǅ ϵ衋ς靐ı]"
+"'{remoteaddress}'. Şḗşşīǿƞ ẇȧş ȧŀřḗȧḓẏ ȧşşǿƈīȧŧḗḓ ȧş '{existinguri}' ǋſǈϖſ靐"
+"衋ſ ǲ靐ǋ鶱ǈǅǅ ϵ衋ς靐ı]"
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Session already associated"
@@ -98,8 +72,8 @@ msgstr ""
 msgid ""
 "Authorizing '{messageid}' for '{destination}' - '{allowed}': '{message}'"
 msgstr ""
-"[Ȧŭŧħǿřīzīƞɠ '{messageid}' ƒǿř '{destination}' - '{allowed}': '{message}' "
-"衋靐ϑς衋ǲϰǲΰς鶱]"
+"[Ȧŭŧħǿřīzīƞɠ '{messageid}' ƒǿř '{destination}' - '{allowed}': '{message}' 衋"
+"靐ϑς衋ǲϰǲΰς鶱]"
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Processing PCP message from '{uri}': '{rawmsg}'"
@@ -109,6 +83,7 @@ msgstr "[Ƥřǿƈḗşşīƞɠ ƤƇƤ ḿḗşşȧɠḗ ƒřǿḿ '{uri}': '{raw
 msgid "Message not authenticated"
 msgstr "[Ḿḗşşȧɠḗ ƞǿŧ ȧŭŧħḗƞŧīƈȧŧḗḓ ǲϰϖǲςΐǲ ſǋſ]"
 
+#. TODO(ale): use 'unauthorized' in version 2
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Message not authorized"
 msgstr "[Ḿḗşşȧɠḗ ƞǿŧ ȧŭŧħǿřīzḗḓ ſ衋ϰϑϑΰ靐 ϐǅϕ]"
@@ -153,6 +128,11 @@ msgid "No client certificate"
 msgstr "[Ƞǿ ƈŀīḗƞŧ ƈḗřŧīƒīƈȧŧḗ ΐϐ 鶱ǋ衋ϑϱΐ]"
 
 #: src/puppetlabs/pcp/broker/core.clj
+#, fuzzy
+msgid "All controllers disconnected"
+msgstr "[ƞǿŧ ƈǿƞƞḗƈŧḗḓ ǅϕ靐 鶱衋ǋϰſǅǈ]"
+
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Node with URI '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"
@@ -173,10 +153,20 @@ msgid "Websocket error '{commonname}' '{remoteaddress}'"
 msgstr "[Ẇḗƀşǿƈķḗŧ ḗřřǿř '{commonname}' '{remoteaddress}' ϑǲǲϵ衋ςǲΰΐ]"
 
 #: src/puppetlabs/pcp/broker/core.clj
-msgid "'{uri}' disconnected from '{remoteaddress}' '{statuscode}' '{reason}'"
+#, fuzzy
+msgid "'{uri}' disconnected '{statuscode}' '{reason}'"
 msgstr ""
-"['{uri}' ḓīşƈǿƞƞḗƈŧḗḓ ƒřǿḿ '{remoteaddress}' '{statuscode}' '{reason}' "
-"鶱ẛǈϰ鶱ǲǅ ϱΐ]"
+"['{uri}' ḓīşƈǿƞƞḗƈŧḗḓ ƒřǿḿ '{remoteaddress}' '{statuscode}' '{reason}' 鶱ẛǈϰ"
+"鶱ǲǅ ϱΐ]"
+
+#: src/puppetlabs/pcp/broker/core.clj
+#, fuzzy
+msgid "Received PCP message from '{uri}': '{rawmsg}'"
+msgstr "[Ƥřǿƈḗşşīƞɠ ƤƇƤ ḿḗşşȧɠḗ ƒřǿḿ '{uri}': '{rawmsg}' ς衋ΰΐſϐΐϖǋǋ]"
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Connecting to '{pcpuri}' at '{uri}'"
+msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "v2 protocol endpoint not configured"
@@ -201,3 +191,42 @@ msgstr "[Şħŭŧŧīƞɠ ḓǿẇƞ ƀřǿķḗř şḗřṽīƈḗ ϕϑǋǅǲ�
 #: src/puppetlabs/pcp/broker/service.clj
 msgid "Broker service <'{brokername}'> stopped"
 msgstr "[Ɓřǿķḗř şḗřṽīƈḗ <'{brokername}'> şŧǿƥƥḗḓ ϰςϑϕſǋ ϖ鶱ϱ]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Sending PCP message to '{uri}': '{rawmsg}'"
+msgstr "[Şḗƞḓīƞɠ ƤƇƤ ḿḗşşȧɠḗ ŧǿ '{uri}': '{rawmsg}' ǲϖϱǈǋǲǅ ſſ]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Error in send-error-message"
+msgstr "[Ḗřřǿř īƞ şḗƞḓ-ḗřřǿř-ḿḗşşȧɠḗ ıϐſ靐靐 靐ΰ 鶱]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Failed to deliver '{messageid}' for '{destination}': '{reason}'"
+msgstr ""
+"[Ƒȧīŀḗḓ ŧǿ ḓḗŀīṽḗř '{messageid}' ƒǿř '{destination}': '{reason}' ΰϵẛſϵϰ ϵǅ]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Delivering '{messageid}' to '{destination}' at '{remoteaddress}'"
+msgstr ""
+"[Ḓḗŀīṽḗřīƞɠ '{messageid}' ŧǿ '{destination}' ȧŧ '{remoteaddress}' ϕϐǲϑΐſǲΰϖ]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "Error in deliver-message"
+msgstr "[Ḗřřǿř īƞ ḓḗŀīṽḗř-ḿḗşşȧɠḗ ǈǲΐ靐ς ΐ靐 ΐ]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+msgid "not connected"
+msgstr "[ƞǿŧ ƈǿƞƞḗƈŧḗḓ ǅϕ靐 鶱衋ǋϰſǅǈ]"
+
+#: src/puppetlabs/pcp/broker/shared.clj
+#, fuzzy
+msgid "client no longer connected"
+msgstr "[Ḿŭŀŧīƥŀḗ řḗƈīƥīḗƞŧş ƞǿ ŀǿƞɠḗř şŭƥƥǿřŧḗḓ ΰſςϑϵςΐϕ ϰ]"
+
+#, fuzzy
+#~ msgid "Stale controller connection"
+#~ msgstr "[ƞǿŧ ƈǿƞƞḗƈŧḗḓ ǅϕ靐 鶱衋ǋϰſǅǈ]"
+
+#, fuzzy
+#~ msgid "Controller disconnection has exceeded grace period."
+#~ msgstr "[ƞǿŧ ƈǿƞƞḗƈŧḗḓ ǅϕ靐 鶱衋ǋϰſǅǈ]"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -115,6 +115,10 @@ msgid "No client certificate"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
+msgid "All controllers disconnected"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Node with URI '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,6 @@
 
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
-
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
@@ -37,7 +36,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "1.1.0"]
+                 [puppetlabs/pcp-client "1.1.1"]
                  [puppetlabs/pcp-common "1.1.1"]
 
                  [puppetlabs/i18n]]

--- a/src/puppetlabs/pcp/broker/inventory.clj
+++ b/src/puppetlabs/pcp/broker/inventory.clj
@@ -10,6 +10,7 @@
 (s/defn init-database :- shared/BrokerDatabase
   []
   {:inventory          {}
+   :warning-bin        {}
    :updates            []
    :first-update-index 0
    :subscriptions      {}})
@@ -113,7 +114,7 @@
                          (update :updates (fn [updates] (vec (subvec updates processed-updates-count))))
                          (update :first-update-index unchecked+ processed-updates-count)))))
 
-(s/defn ^:private send-updates
+(s/defn send-updates
   [broker :- Broker]
   "Send inventory update messages to subscribed clients. Subsequently remove the processed inventory
   change records from the :updates vector."

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -30,6 +30,9 @@
   (start [this context]
          (sl/maplog :info {:type :broker-start} (i18n/trs "Starting broker service"))
          (let [controller-uris (get-in-config [:pcp-broker :controller-uris] [])
+               controller-disconnection-graceperiod (get-in-config [:pcp-broker
+                                                                    :controller-disconnection-graceperiod]
+                                                                   45000)
                controller-whitelist (set (get-in-config [:pcp-broker :controller-whitelist]
                                                         ["http://puppetlabs.com/inventory_request"]))
                broker (:broker context)
@@ -50,7 +53,8 @@
                    (core/initiate-controller-connections broker
                                                          ssl-context
                                                          controller-uris
-                                                         controller-whitelist))
+                                                         controller-whitelist
+                                                         controller-disconnection-graceperiod))
            (core/start broker)
            (sl/maplog :debug {:type :broker-started :brokername broker-name}
                       (i18n/trs "Broker service <'{brokername}'> started"))

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -11,6 +11,7 @@
             [schema.core :as s]
             [puppetlabs.i18n.core :as i18n])
   (:import [puppetlabs.pcp.broker.connection Connection]
+           [org.joda.time DateTime]
            [clojure.lang IFn]))
 
 (def BrokerState
@@ -37,6 +38,7 @@
    ;; the index of the first InventoryChange record in the :updates vector
    ;; (note that this index can overflow)
    :first-update-index s/Int
+   :warning-bin        {p/Uri DateTime}
    :updates            [p/InventoryChange]
    :subscriptions      {p/Uri Subscription}})
 

--- a/test/unit/puppetlabs/pcp/broker/core_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/core_test.clj
@@ -388,7 +388,7 @@
             _ (.start ssl-context-factory)
             ssl-context (.getSslContext ssl-context-factory)
             _ (.stop ssl-context-factory)
-            clients (initiate-controller-connections broker ssl-context ["wss://foo.com/v1"] #{})
+            clients (initiate-controller-connections broker ssl-context ["wss://foo.com/v1"] #{} 100)
             client (get clients "pcp://foo.com/server")]
         (is (= 1 (count clients)))
         (is client)


### PR DESCRIPTION
When all configured controllers become disconnected from the broker,
schedule a task after a grace period (set to 45 seconds) that will
disconnect all clients. If a broker reconnects in that time, do not run
the task. Refuse client connections when all brokers are disconnected.