### PR TITLE
(maint) No controller config by default

### DIFF
--- a/test-resources/conf.d/pcp-broker.conf
+++ b/test-resources/conf.d/pcp-broker.conf
@@ -1,5 +1,5 @@
 pcp-broker: {
-  controller-uris: ["wss://localhost:8143/server"]
+  #controller-uris: ["wss://localhost:8143/server"]
   controller-whitelist: ["http://puppetlabs.com/inventory_request",
                          "http://puppetlabs.com/rpc_blocking_request",
                          "http://puppetlabs.com/rpc_non_blocking_request"]


### PR DESCRIPTION
A default controller config will cause pcp-broker to refuse connections.
This will cause pxp-agent acceptance tests that run against pcp-broker
to fail.