### PR TITLE
(PCP-701) Fix state to report starting and stopping

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -587,7 +587,7 @@
   (let [timestamp (now)]
     (swap! (:database broker) update :subscriptions dissoc uri)
     (swap! (:database broker) update :warning-bin assoc uri timestamp)
-    (when (all-controllers-disconnected? broker)
+    (when (and (= :running @(:state broker)) (all-controllers-disconnected? broker))
       (schedule-client-purge! broker timestamp controller-disconnection-graceperiod uri))))
 
 (s/defn start-client

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -672,10 +672,11 @@
 (s/defn status :- status-core/StatusCallbackResponse
   [broker :- Broker level :- status-core/ServiceStatusDetailLevel]
   (let [{:keys [state metrics-registry]} broker
-        level>= (partial status-core/compare-levels >= level)]
-    {:state (if (all-controllers-disconnected? broker)
+        level>= (partial status-core/compare-levels >= level)
+        state-now @state]
+    {:state (if (and (= state-now :running) (all-controllers-disconnected? broker))
               :error
-              @state)
+              state-now)
      :status (cond-> {}
                (level>= :info) (assoc :metrics (metrics/get-pcp-metrics metrics-registry))
                (level>= :debug) (assoc :threads (metrics/get-thread-metrics)

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -161,7 +161,8 @@
                    :sender "pcp:///server"
                    :data response-data})]
      (try
-       (send-message connection message)
+       (locking (:websocket connection)
+         (send-message connection message))
        (catch Exception e
          (sl/maplog :debug e
                     {:type :message-delivery-error}

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -110,7 +110,8 @@
                              :data description})
                           in-reply-to-message (assoc :in_reply_to (:id in-reply-to-message)))]
     (try
-      (send-message connection error-msg)
+      (locking (:websocket connection)
+        (send-message connection error-msg))
       (catch Exception e
         (sl/maplog :debug e
                    {:type :message-delivery-error}


### PR DESCRIPTION
In a previous commit, status was changed to report error if all
controllers were disconnected. However, this is also normal behavior
when starting or stopping the service, which made status less
illuminating. Restore reporting starting and stopping status, and only
report error if the broker is running and all controllers are
disconnected.