### PR TITLE
(ORCH-1601) add connection limit

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -80,17 +80,19 @@ web-router-service: {
 }
 ```
 
-The broker can also be configured to make out-bound connections to other PCP servers. The
-connection is configured by providing a list of Websocket URIs, and optionally a whitelist
-of message types allowed to those connections. If the whitelist is not specified, only
-inventory requests are authorized. Note that all URIs must use a distinct hostname/port
-combination (the path is not taken into account when generating PCP identifiers).
+The broker exposes several configuration options around controller and client
+connections in the `pcp-broker` section. These options are:
 
-Users may also supply a controller disconnection graceperiod, which represents
-the amount of time to wait after all controllers become disconnected before
-evicting all client connections (to allow them to redistribute to other
-brokers). If unspecified, this defaults to 45 seconds. The parameter is
-supplied in milliseconds.
+* controller-uris: An array of Websocket URIs to which the broker will attempt
+  to establish outbound connections.
+* controller-whitelist: An array of message types the broker will accept from
+  connected controllers. Defaults to accepting only inventory requests.
+* controller-disconnection-graceperiod: The number of milliseconds after losing
+  connectivity to all configured controllers that the broker will wait before
+  dropping all connected clients (to allow them to redistribute to other
+  brokers).
+* max-connections: The maximum number of clients that can connect to the
+  broker. Defaults to 0, which is interpreted as unlimited.
 
 ```
 pcp-broker: {
@@ -98,5 +100,6 @@ pcp-broker: {
     controller-whitelist: ["http://puppetlabs.com/inventory_request",
                            "http://puppetlabs.com/rpc_blocking_request"],
     controller-disconnection-graceperiod: 45000
+    max-connections: 10000
 }
 ```

--- a/locales/eo.po
+++ b/locales/eo.po
@@ -2,7 +2,7 @@
 # Copyright (C) YEAR Puppet <docs@puppet.com>
 # This file is distributed under the same license as the puppetlabs.pcp_broker package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -12,10 +12,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid ""
@@ -23,8 +23,8 @@ msgid ""
 "'{remoteaddress}'. Session was already associated as '{existinguri}'"
 msgstr ""
 "[Řḗƈḗīṽḗḓ şḗşşīǿƞ ȧşşǿƈīȧŧīǿƞ ƒǿř '{uri}' ƒřǿḿ '{commonname}' "
-"'{remoteaddress}'. Şḗşşīǿƞ ẇȧş ȧŀřḗȧḓẏ ȧşşǿƈīȧŧḗḓ ȧş '{existinguri}' "
-"衋ǈǈϕϵẛϵ鶱 ϐǅϐ鶱衋ǈ衋 ϖ衋ςςϰ]"
+"'{remoteaddress}'. Şḗşşīǿƞ ẇȧş ȧŀřḗȧḓẏ ȧşşǿƈīȧŧḗḓ ȧş '{existinguri}' 衋ǈǈϕϵẛϵ"
+"鶱 ϐǅϐ鶱衋ǈ衋 ϖ衋ςςϰ]"
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Session already associated"
@@ -128,6 +128,15 @@ msgid "No client certificate"
 msgstr "[Ƞǿ ƈŀīḗƞŧ ƈḗřŧīƒīƈȧŧḗ ǋǈ ςǲ靐ıſ衋]"
 
 #: src/puppetlabs/pcp/broker/core.clj
+#, fuzzy
+msgid "All controllers disconnected"
+msgstr "[ƈŀīḗƞŧ ƞǿ ŀǿƞɠḗř ƈǿƞƞḗƈŧḗḓ ϕ靐靐鶱ſΰ ϖϖ ϱ]"
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Connection limit exceeded"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Node with URI '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"
@@ -154,6 +163,23 @@ msgstr "['{uri}' ḓīşƈǿƞƞḗƈŧḗḓ '{statuscode}' '{reason}' ϖſ鶱�
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Received PCP message from '{uri}': '{rawmsg}'"
 msgstr "[Řḗƈḗīṽḗḓ ƤƇƤ ḿḗşşȧɠḗ ƒřǿḿ '{uri}': '{rawmsg}' ϕǲϵΰǲϰϕϱ ϖ]"
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Established connection with controller '{uri}'"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Scheduled full client eviction in '{timeout}' ms"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
+#, fuzzy
+msgid "Lost connection to controller: '{uri}'"
+msgstr "[Ƈǿƞƞḗƈŧīƞɠ ŧǿ '{pcpuri}' ȧŧ '{uri}' ǈΐϱẛ衋ſϕǲıı]"
+
+#: src/puppetlabs/pcp/broker/core.clj
+msgid "Removing inventory update subscription for '{uri}'"
+msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
 msgid "Connecting to '{pcpuri}' at '{uri}'"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -119,6 +119,10 @@ msgid "All controllers disconnected"
 msgstr ""
 
 #: src/puppetlabs/pcp/broker/core.clj
+msgid "Connection limit exceeded"
+msgstr ""
+
+#: src/puppetlabs/pcp/broker/core.clj
 msgid ""
 "Node with URI '{uri}' already associated with connection '{commonname}' "
 "'{remoteaddress}'"

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -20,9 +20,11 @@
    [:StatusService register-status]]
   (init [this context]
         (sl/maplog :info {:type :broker-init} (i18n/trs "Initializing broker service"))
-        (let [broker             (core/init {:add-websocket-handler (partial add-websocket-handler this)
+        (let [max-connections    (get-in-config [:pcp-broker :max-connections] 0)
+              broker             (core/init {:add-websocket-handler (partial add-websocket-handler this)
                                              :authorization-check   authorization-check
                                              :get-metrics-registry  get-metrics-registry
+                                             :max-connections       max-connections
                                              :get-route             (partial get-route this)})]
           (register-status "broker-service"
                            (status-core/get-artifact-version "puppetlabs" "pcp-broker")

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -45,6 +45,7 @@
 (def Broker
   {:broker-name         (s/maybe s/Str)
    :authorization-check IFn
+   :max-connections     s/Int
    :database            (s/atom BrokerDatabase)
    :controllers         (s/atom {p/Uri Connection})
    :should-stop         Object                              ;; Promise used to signal the inventory updates should stop

--- a/test/integration/puppetlabs/pcp/broker/controllers_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/controllers_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.pcp.broker.controllers-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.testutils :refer [dotestseq]]
+            [puppetlabs.pcp.testutils :refer [dotestseq received?]]
             [puppetlabs.pcp.testutils.service :refer [protocol-versions broker-services get-broker get-context]]
             [puppetlabs.pcp.testutils.client :as client]
             [puppetlabs.pcp.testutils.server :as server]
@@ -262,14 +262,6 @@
               (inventory/send-updates (get-broker app))
               (is (empty? (:updates @(:database broker))))
               (is (= @server-messages-at-unsubscribe @server-message-sent)))))))))
-
-(defn received?
-  "We sometimes see a 1006/abnormal close.
-   This can be removed when PCP-714 is addressed."
-  [response expected]
-  (let [[status message] response]
-    (or (= 1006 status)
-        (= response expected))))
 
 (deftest controller-disconnection
     (let [timed-out? (promise)]

--- a/test/unit/puppetlabs/pcp/broker/shared_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/shared_test.clj
@@ -22,6 +22,7 @@
                 :authorization-check (constantly true)
                 :database            (atom (inventory/init-database))
                 :controllers         (atom {})
+                :max-connections     0
                 :should-stop         (promise)
                 :metrics             {}
                 :metrics-registry    metrics.core/default-registry

--- a/test/utils/puppetlabs/pcp/testutils.clj
+++ b/test/utils/puppetlabs/pcp/testutils.clj
@@ -12,3 +12,11 @@
                                      '~case-versions
                                      (list ~@case-versions))))
            ~@body)))))
+
+(defn received?
+  "We sometimes see a 1006/abnormal close.
+   This can be removed when PCP-714 is addressed."
+  [response expected]
+  (let [[status message] response]
+    (or (= 1006 status)
+        (= response expected))))

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -14,7 +14,8 @@
   (sendbytes! [_ bytes])
   (send! [_ message])
   (recv! [_] [_ timeout]
-    "Returns nil on timeout, [code reason] on close, message/Message on message"))
+    "Returns nil on timeout, [code reason] on close, message/Message on message")
+  (connected? [_]))
 
 (defrecord ChanClient [http-client ws-client message-channel]
   WsClient
@@ -32,7 +33,9 @@
   (recv! [this] (recv! this (* 10 5 1000)))
   (recv! [_ timeout-ms]
     (let [[message channel] (alts!! [message-channel (timeout timeout-ms)])]
-      message)))
+      message))
+  (connected? [_]
+    (.isOpen ws-client)))
 
 (defn http-client-with-cert
   [certname]


### PR DESCRIPTION
Add a config setting to limit the number of client connections allowed
to the broker. Defaults to 0 (unlimited).