### PR TITLE
(PE-19981) Bump to clj-parent 0.6.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.6.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.6.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -41,7 +41,7 @@
                  [puppetlabs/i18n]]
 
   :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.7.1"]
+            [puppetlabs/i18n "0.8.0"]
             [lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
   :lein-release {:scm :git

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.6.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/resources/ext/config/conf.d/metrics.conf
+++ b/resources/ext/config/conf.d/metrics.conf
@@ -1,16 +1,65 @@
 metrics: {
-    # needed till version with TK-252 ships
-    enabled: true
-
     # a server id that will be used as part of the namespace for metrics produced
     # by this server
     server-id: localhost
 
-    # this section is used to enable/disable JMX reporting
-    reporters: {
-        # enable or disable JMX metrics reporter
-        jmx: {
-            enabled: true
+    registries: {
+        default: {
+            reporters: {
+
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+        }
+        puppetlabs.orchestrator: {
+            reporters: {
+
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+        }
+    }
+
+    # this section is used to configure host, port, and update-interval-seconds
+    # for reporters.
+    #reporters: {
+    #    graphite: {
+    #        # graphite host
+    #        host: "127.0.0.1"
+    #        # graphite metrics port
+    #        port: 2003
+    #        # how often to send metrics to graphite
+    #        update-interval-seconds: 60
+    #    }
+    #}
+
+    metrics-webservice: {
+        jolokia: {
+            # Enable or disable the Jolokia-based metrics/v2 endpoint.
+            # Default is true.
+            #enabled: false
+
+            # Configure any of the settings listed at:
+            #   https://jolokia.org/reference/html/agents.html#war-agent-installation
+            #servlet-init-params: {
+            #    # Specify a custom security policy:
+            #    #  https://jolokia.org/reference/html/security.html
+            #    policyLocation: "file:///etc/puppetlabs/<service name>/jolokia-access.xml"
+            #}
         }
     }
 }

--- a/test/utils/puppetlabs/pcp/testutils/service.clj
+++ b/test/utils/puppetlabs/pcp/testutils/service.clj
@@ -34,8 +34,7 @@
                                                    :v2 "/pcp/v2.0"}
     :puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"}
 
-   :metrics {:enabled true
-             :server-id "localhost"}})
+   :metrics {:server-id "localhost"}})
 
 (def protocol-versions
   "The short names of versioned endpoints"


### PR DESCRIPTION
Bump to clj-parent 0.6.1 which includes trapperkeeper-metrics 1.0.0.

No code changes are required for this update.

The `:enabled` setting in the test metrics config was removed as this setting
had been deprecated and acted as a no-op for a long time; tk-metric 1.0.0
removed it entirely.

The metrics.conf included in packaging was updated to match the new config for
tk-metrics 1.0. As with the previous metrics.conf, it enables the JMX metrics
reporter. It also includes commented out example config for configuring the
Graphite reporter. The updates to this config file are not expected to cause
any problems because 1) it was never configurable using the PE module, and 2)
there is no documentation for how to configure any settings in it.