### PR TITLE
(maint) raise default controller disconnection graceperiod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.1
+
+This is a maintenance release
+
+* Bump the default controller-disconnection-graceperiod setting from 45000 to
+  90000, to allow ample time for service restarts.
+* Bump clj-pcp-client to version 1.1.5
+
 ## 1.3.0
 
 This is a feature release.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -90,7 +90,7 @@ connections in the `pcp-broker` section. These options are:
 * controller-disconnection-graceperiod: The number of milliseconds after losing
   connectivity to all configured controllers that the broker will wait before
   dropping all connected clients (to allow them to redistribute to other
-  brokers).
+  brokers). Defaults to 90s.
 * max-connections: The maximum number of clients that can connect to the
   broker. Defaults to 0, which is interpreted as unlimited.
 
@@ -99,7 +99,7 @@ pcp-broker: {
     controller-uris: ["wss://broker.example.com:8143/server", "wss://broker2.example.com:8143/server"],
     controller-whitelist: ["http://puppetlabs.com/inventory_request",
                            "http://puppetlabs.com/rpc_blocking_request"],
-    controller-disconnection-graceperiod: 45000
+    controller-disconnection-graceperiod: "90s"
     max-connections: 10000
 }
 ```

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.6.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.7.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -36,7 +36,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "1.1.4"]
+                 [puppetlabs/pcp-client "1.1.5"]
 
                  [puppetlabs/i18n]]
 


### PR DESCRIPTION
45000 seems a bit too aggressive, since JVM restarts could plausibly
take that long. This bumps the timeout to 90000.