### PR TITLE
(PCP-741) Upgrade jetty to 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: clojure
 sudo: false
 lein: 2.7.1
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk8
 script:
   - lein test
   - lein with-profile test-schema-validation test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.2
+
+This is a maintenance release
+
+* Bump clj-parent to 1.0.0 which upgrades jetty to 9.4
+
 ## 1.3.1
 
 This is a maintenance release

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.8.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.0.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -29,14 +29,14 @@
 
                  [cheshire]
 
-                 [com.taoensso/nippy "2.9.0"]
+                 [com.taoensso/nippy]
 
                  [metrics-clojure "2.5.1"]
 
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "1.1.5"]
+                 [puppetlabs/pcp-client "1.1.6"]
 
                  [puppetlabs/i18n]]
 

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -32,16 +32,11 @@
   entries in the key store of the specified org.eclipse.jetty.util.ssl.SslContextFactory
   instance - `ssl-context-factory`."
   [ssl-context-factory]
-  (try
-    (let [load-key-store-method (doto
-                                 (-> (class ssl-context-factory)
-                                     (.getDeclaredMethod "loadKeyStore" (into-array Class [])))
-                                  (.setAccessible true))
-          ^KeyStore key-store (.invoke load-key-store-method ssl-context-factory (into-array Object []))]
+  (let [^KeyStore key-store (.getKeyStore ssl-context-factory)]
+    (when key-store
       (->> (.aliases key-store)
            enumeration-seq
-           (some #(.getCertificateChain key-store %))))
-    (catch Exception _)))
+           (some #(.getCertificateChain key-store %))))))
 
 (s/defn get-webserver-cn :- (s/maybe s/Str)
   "Return the common name from the certificate the webserver specified by its

--- a/test/utils/puppetlabs/pcp/testutils/server.clj
+++ b/test/utils/puppetlabs/pcp/testutils/server.clj
@@ -52,5 +52,10 @@
 
 (defn wait-for-inbound-connection
   [svc-context]
-  (while (empty? @(:inventory svc-context))
-    (Thread/sleep 100)))
+  (loop [i 0]
+    (when (empty? @(:inventory svc-context))
+      (if (> i 50)
+        (throw (Exception. "Test timed out waiting for inbound connection"))
+        (do
+         (Thread/sleep 100)
+         (recur (inc i)))))))


### PR DESCRIPTION
blocked on https://github.com/puppetlabs/clj-pcp-client/pull/77

This changed the method of instrospecting brokername from the ssl
context to use only public methods.