### PR TITLE
(maint) Cleanup dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.4
+
+This is a maintenance release
+
+* Bump clj-parent to 1.1.0 which adds versioning for metrics-clojure, bump
+  metrics-clojure from 2.5.1 to 2.6.1 as a result, remove unused dependencies
+
 ## 1.3.3
 
 This is a maintenance release

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.0.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.1.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -26,12 +26,8 @@
                  [puppetlabs/trapperkeeper-status]
 
                  [puppetlabs/structured-logging]
-
-                 [cheshire]
-
-                 [com.taoensso/nippy]
-
-                 [metrics-clojure "2.5.1"]
+                 [puppetlabs/ssl-utils]
+                 [metrics-clojure]
 
                  ;; try+/throw+
                  [slingshot]
@@ -62,7 +58,6 @@
                                   [http.async.client ~http-async-client-version]
                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink :classifier "test" :scope "test"]
-                                  [puppetlabs/ssl-utils]
                                   [org.clojure/tools.namespace]]
                    :plugins [[lein-cloverage "1.0.6" :excludes [org.clojure/clojure org.clojure/tools.cli]]]}
              :dev-schema-validation [:dev


### PR DESCRIPTION
Remove unused dependencies, and pickup metrics-clojure from clj-parent.
Bump to clj-parent 1.1.0 for the addition of metrics-clojure. We also
use ssl-utils in the core implementation, so move it out of test-only
dependencies into standard dependencies.