### PR TITLE
(PCP-737) Handle events on stale connection gracefully

### DIFF
--- a/src/puppetlabs/pcp/broker/util.clj
+++ b/src/puppetlabs/pcp/broker/util.clj
@@ -1,4 +1,5 @@
-(ns puppetlabs.pcp.broker.util)
+(ns puppetlabs.pcp.broker.util
+  (:require [schema.core :as s]))
 
 (defn update-cond
   "Works like update, but only if pred is satisfied"
@@ -28,3 +29,8 @@
 (defn ensure-vec
   [v]
   (if (vector? v) v (vector v)))
+
+(s/defn hexdump :- s/Str
+  [data :- (s/either bytes s/Str)]
+  (let [bytes (if (string? data) (.getBytes data) data)]
+    (clojure.string/join " " (map #(format "%02X" %) bytes))))


### PR DESCRIPTION
This PR makes sure errors or messages received on stale websocket connections are handled gracefully. A stale connection in this context means a connection which is not present in the broker's inventory any longer.
Previously it was not the case which could lead to validation errors when there was an attempt to log the connection details for connection which was not found in the broker's inventory.