### PR TITLE
(PCP-735) Allow disconnect to resolve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ lein: 2.7.1
 jdk:
   - oraclejdk8
 script:
-  - lein test
-  - lein with-profile test-schema-validation test
-  - chmod +x $TRAVIS_BUILD_DIR/ext/travisci/secscan.sh
-  - $TRAVIS_BUILD_DIR/ext/travisci/secscan.sh "$TRAVIS_BUILD_DIR/src" "clj" "clojure.core/read-string"
+  - lein $TEST_OPTIONS test
+  - if [ "$TEST_OPTIONS" = "" ]; then ./ext/travisci/secscan.sh src clj "clojure.core/read-string"; fi
+env:
+  - TEST_OPTIONS=""
+  - TEST_OPTIONS="with-profile test-schema-validation"
 notifications:
   email: false

--- a/test/integration/puppetlabs/pcp/broker/controllers_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/controllers_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.pcp.broker.controllers-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.pcp.testutils :refer [dotestseq received?]]
+            [puppetlabs.pcp.testutils :refer [dotestseq received? retry-until-true]]
             [puppetlabs.pcp.client :as pcp-client]
             [puppetlabs.pcp.testutils.service :refer [protocol-versions broker-services get-broker get-context]]
             [puppetlabs.pcp.testutils.client :as client]
@@ -368,4 +368,6 @@
           (is (= :error (:state (core/status broker :info))))
           (with-app-with-config mock-server server/mock-server-services mock-server-config
             (server/wait-for-inbound-connection (get-context mock-server :MockServer))
+            ;; Allow time for the controller client connection to register as connected.
+            (is (retry-until-true 10 #(not (core/all-controllers-disconnected? broker))))
             (is (= :running (:state (core/status broker :info))))))))))

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.pcp.broker.service-test
   (:require [clojure.test :refer :all]
             [http.async.client :as http]
-            [puppetlabs.pcp.testutils :refer [dotestseq received?]]
+            [puppetlabs.pcp.testutils :refer [dotestseq received? retry-until-true]]
             [puppetlabs.pcp.testutils.service :refer [broker-config protocol-versions broker-services]]
             [puppetlabs.pcp.testutils.client :as client]
             [puppetlabs.pcp.message-v1 :as m1]
@@ -533,7 +533,8 @@
         (is (client/connected? client1))
         (is (received? (client/recv! client2)
                        [1011 "Connection limit exceeded."]))
-        (is (not (client/connected? client2)))))))
+        ;; Allow time for the websocket object to be closed.
+        (is (retry-until-true 10 #(not (client/connected? client2))))))))
 
 (deftest interversion-send-test
   (with-app-with-config app broker-services broker-config

--- a/test/utils/puppetlabs/pcp/testutils.clj
+++ b/test/utils/puppetlabs/pcp/testutils.clj
@@ -20,3 +20,11 @@
   (let [[status message] response]
     (or (= 1006 status)
         (= response expected))))
+
+(defn retry-until-true
+  [times condf]
+  (Thread/sleep 1)
+  (cond
+    (condf) true
+    (not (pos? times)) false
+    :else (recur (dec times) condf)))


### PR DESCRIPTION
Introduce a small wait after receiving the on-close message to ensure
the websocket object registers that the connection is closed.