### PR TITLE
(PCP-760) Wait for connection before processing controller messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.1
+
+This is a maintenance release
+
+* [PCP-760](https://tickets.puppetlabs.com/browse/PCP-760) Fix an issue where
+    requests received immediately after connecting to a controller may be
+    ignored.
+
 ## 1.4.0
 
 This is a feature release.

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -58,10 +58,13 @@
   (-> broker :database deref :inventory (get uri)))
 
 (s/defn get-controller :- (s/maybe Connection)
-  [broker :- Broker uri :- p/Uri]
-  (if-let [controller (get @(:controllers broker) uri)]
-    (if (pcp-client/connected? (:websocket controller))
-      controller)))
+  ([broker :- Broker uri :- p/Uri]
+   (get-controller broker uri 0))
+  ([broker :- Broker uri :- p/Uri timeout :- s/Int]
+   (when-let [controller (get @(:controllers broker) uri)]
+     (pcp-client/wait-for-connection (:websocket controller) timeout)
+     (if (pcp-client/connected? (:websocket controller))
+       controller))))
 
 (s/defn build-and-register-metrics :- {s/Keyword Object}
   [broker :- Broker]


### PR DESCRIPTION
When a PCP connection from pcp-broker to the controller (orchestrator) is
established, there is a brief window of time during which the connection is
able to receive messages but is not yet considered
"connected" by our internal record-keeping.

The first thing orchestrator does when a broker connects is immediately
send an inventory request.  The inconsistency in state in the broker means
that it's possible it will receive that request before it thinks it's
connected, and currently it will reject the message. That causes
orchestrator to never receive an inventory response (or subsequent
inventory updates) from the broker, rendering any agents connected to that
broker inaccessible until one service or the other is restarted.

This inconsistency happens because we have multiple layers of clojure code
tracking state on top of the underlying java object. In short, it can take
a small amount of time for every layer of the stack to learn that the
connection is ready to go.

Because of an implementation detail of gniazdo, our underlying clojure
websockets library, we aren't actually able to get ahold of the connection
object until it's "connected" from gniazdo's point-of-view. That means the
only way to address this issue is to wait for the connection to be
available *before* processing the message.

The solution for the short term is to make pcp-broker wait for the
connection to be fully established if it happens to receive a message
during the "connecting" state. We wait just 1 second, because the only work
that should need to be done is delivering some promises and completing some
futures. In the common case, where orchestrator already is connected, this
should add no additional overhead.