### PR TITLE
(PCP-777) Reject connections before websocket upgrade

### DIFF
--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -12,6 +12,7 @@
             [puppetlabs.i18n.core :as i18n])
   (:import [puppetlabs.pcp.broker.connection Connection]
            [org.joda.time DateTime]
+           [org.eclipse.jetty.server.handler ContextHandler]
            [clojure.lang IFn]))
 
 (def BrokerState
@@ -51,7 +52,8 @@
    :should-stop         Object                              ;; Promise used to signal the inventory updates should stop
    :metrics-registry    Object
    :metrics             {s/Keyword Object}
-   :state               (s/atom BrokerState)})
+   :state               (s/atom BrokerState)
+   :handlers            (s/atom [ContextHandler])})
 
 (s/defn get-connection :- (s/maybe Connection)
   [broker :- Broker uri :- p/Uri]

--- a/test/integration/puppetlabs/pcp/broker/controllers_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/controllers_test.clj
@@ -305,8 +305,7 @@
           (let [{:keys [broker]} (get-context app :BrokerService)
                 database (:database broker)]
             (testing "client connections disallowed when no controller is connected"
-              (with-open [client (client/connect :certname agent-cert)]
-                (is (received? (client/recv! client) [1011 "All controllers disconnected."]))))
+              (is (nil? (client/connect :certname agent-cert))))
             (testing "broker state is error on start (no controllers connected)"
               (is (= :error (:state (core/status broker :info)))))
             (testing "controller disconnection"
@@ -333,7 +332,7 @@
                                          [1011 "All controllers disconnected."]))))
                       (deliver timed-out? true)
                       (is (received? (client/recv! client)
-                                     [1011 "All controllers disconnected."]))
+                                     [1001 "Shutdown"]))
                       (is (not (websockets-client/connected? (:websocket client-connection)))))
                     (testing "warning bin contains one element"
                       (is (= 1 (count (:warning-bin @database)))))))))

--- a/test/unit/puppetlabs/pcp/broker/shared_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/shared_test.clj
@@ -26,7 +26,8 @@
                 :should-stop         (promise)
                 :metrics             {}
                 :metrics-registry    metrics.core/default-registry
-                :state               (atom :running)}
+                :state               (atom :running)
+                :handlers            (atom [])}
         metrics (build-and-register-metrics broker)
         broker (assoc broker :metrics metrics)]
     broker))

--- a/test/utils/puppetlabs/pcp/testutils/client.clj
+++ b/test/utils/puppetlabs/pcp/testutils/client.clj
@@ -100,10 +100,10 @@
                                                      (put! message-chan (m1/decode msg)))
                                             :close (fn [ws code reason]
                                                      (put! message-chan [code reason])))
-        wrapper             (ChanClient. client ws message-chan)]
+        wrapper             (when ws (ChanClient. client ws message-chan))]
 
     ;; session association messages are normally only used in PCP v1
-    (when (and (or (= "v1.0" version) force-association) check-association)
+    (when (and wrapper (or (= "v1.0" version) force-association) check-association)
       (let [response (recv! wrapper)]
         (is (= "http://puppetlabs.com/associate_response" (:message_type response)))
         (is (= (case version
@@ -114,4 +114,5 @@
                (case version
                  "v1.0" (m1/get-json-data response)
                  (m2/get-data response))))))
+
     wrapper))


### PR DESCRIPTION
Accepting websocket upgrades before rejecting the connection causes
clients to get a successful connection before it immediately disappears.
It's difficult to distinguish that this is a configuration issue - vs a
broker going away - to determine whether the client should immediately
attempt to reconnect and get a new broker from the load balancer, or
delay reconnects.

Update the broker to reject connections immediately - by disabling the
routing handler - rather than accepting a websocket upgrade before
disconnecting.