### PR TITLE
(PCP-491) Make max message size configurable

### DIFF
--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -22,10 +22,12 @@
   (init [this context]
         (sl/maplog :info {:type :broker-init} (fn [_] (i18n/trs "Initializing broker service.")))
         (let [max-connections    (get-in-config [:pcp-broker :max-connections] 0)
+              max-message-size   (get-in-config [:pcp-broker :max-message-size] (* 64 1024 1024))
               broker             (core/init {:add-websocket-handler (partial add-websocket-handler this)
                                              :authorization-check   authorization-check
                                              :get-metrics-registry  get-metrics-registry
                                              :max-connections       max-connections
+                                             :max-message-size      max-message-size
                                              :get-route             (partial get-route this)})]
           (register-status "broker-service"
                            (status-core/get-artifact-version "puppetlabs" "pcp-broker")

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -46,6 +46,7 @@
   {:broker-name         (s/maybe s/Str)
    :authorization-check IFn
    :max-connections     s/Int
+   :max-message-size    s/Int
    :database            (s/atom BrokerDatabase)
    :controllers         (s/atom {p/Uri Connection})
    :should-stop         Object                              ;; Promise used to signal the inventory updates should stop

--- a/test/unit/puppetlabs/pcp/broker/shared_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/shared_test.clj
@@ -23,6 +23,7 @@
                 :database            (atom (inventory/init-database))
                 :controllers         (atom {})
                 :max-connections     0
+                :max-message-size    65536
                 :should-stop         (promise)
                 :metrics             {}
                 :metrics-registry    metrics.core/default-registry


### PR DESCRIPTION
Adds a `pcp-broker.max-message-size` configuration option that
configures the max binary message size for WebSocket sessions. This
would allow large messages to be sent by clients.