### PR TITLE
(PCP-854) Honor max-message-size for orchestrator connections

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -735,6 +735,7 @@
         client (pcp-client/connect {:server uri
                                     :ssl-context ssl-context
                                     :type "server"
+                                    :max-message-size (:max-message-size broker)
                                     :on-connect-cb (partial on-controller-connect! broker pcp-uri)
                                     :on-close-cb (partial forget-controller-subscription broker pcp-uri
                                                           controller-disconnection-ms)}


### PR DESCRIPTION
Previously, this setting was only being used to control the max message
size for connections from pxp-agents. That caused orchestrator messages
to use the default 64k limit, which is too small for task requests
involving large metadata. We now thread that setting through to the
outbound connections pcp-broker makes.