### PR TITLE
(ORCH-2261) Configure to build docker image via ezbake

### DIFF
--- a/ezbake/config/docker/bootstrap.cfg
+++ b/ezbake/config/docker/bootstrap.cfg
@@ -1,0 +1,8 @@
+puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
+puppetlabs.pcp.broker.service/broker-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
+puppetlabs.trapperkeeper.services.status.status-service/status-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service

--- a/ezbake/config/docker/conf.d/auth.conf
+++ b/ezbake/config/docker/conf.d/auth.conf
@@ -1,0 +1,76 @@
+authorization: {
+  version: 1
+  rules: [
+      {
+          "allow": [],
+          "match-request": {
+              "path": "/pcp-broker/send",
+              "query-params": {
+                  "destination_report": "true",
+                  "targets": [
+                      "pcp://*/agent",
+                      "pcp://*/*"
+                  ]
+              },
+              "type": "path"
+          },
+          "name": "multi-cast with destination_report",
+          "sort-order": 399
+      }
+  ,
+      {
+          "allow": [
+              ${ORCHESTRATOR}
+          ],
+          "match-request": {
+              "path": "/pcp-broker/send",
+              "query-params": {
+                  "message_type": [
+                      "http://puppetlabs.com/inventory_request"
+                  ]
+              },
+              "type": "path"
+          },
+          "name": "inventory request",
+          "sort-order": 400
+      }
+  ,
+      {
+          "allow": [
+              ${ORCHESTRATOR}
+          ],
+          "match-request": {
+              "path": "/pcp-broker/send",
+              "query-params": {
+                  "message_type": [
+                      "http://puppetlabs.com/rpc_non_blocking_request",
+                      "http://puppetlabs.com/rpc_blocking_request"
+                  ]
+              },
+              "type": "path"
+          },
+          "name": "pxp commands",
+          "sort-order": 400
+      }
+  ,
+      {
+          "allow": "*",
+          "match-request": {
+              "path": "/pcp-broker/send",
+              "query-params": {
+                  "message_type": [
+                      "http://puppetlabs.com/associate_request",
+                      "http://puppetlabs.com/rpc_provisional_response",
+                      "http://puppetlabs.com/rpc_blocking_response",
+                      "http://puppetlabs.com/rpc_non_blocking_response",
+                      "http://puppetlabs.com/rpc_error_message"
+                  ]
+              },
+              "type": "path"
+          },
+          "name": "pcp-broker message",
+          "sort-order": 420
+      }
+
+  ]
+}

--- a/ezbake/config/docker/conf.d/global.conf
+++ b/ezbake/config/docker/conf.d/global.conf
@@ -1,0 +1,10 @@
+global: {
+    # Path to logback logging configuration file; for more
+    # info, see http://logback.qos.ch/manual/configuration.html
+    logging-config: /config/logback.xml
+    certs: {
+      ssl-ca-cert: "/ssl/ca.pem"
+      ssl-cert: "/ssl/cert.pem"
+      ssl-key: "/ssl/key.pem"
+    }
+}

--- a/ezbake/config/docker/conf.d/metrics.conf
+++ b/ezbake/config/docker/conf.d/metrics.conf
@@ -1,0 +1,51 @@
+metrics: {
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+
+    registries: {
+        default: {
+            reporters: {
+
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+        }
+    }
+
+    # this section is used to configure host, port, and update-interval-seconds
+    # for reporters.
+    #reporters: {
+    #    graphite: {
+    #        # graphite host
+    #        host: "127.0.0.1"
+    #        # graphite metrics port
+    #        port: 2003
+    #        # how often to send metrics to graphite
+    #        update-interval-seconds: 60
+    #    }
+    #}
+
+    metrics-webservice: {
+        jolokia: {
+            # Enable or disable the Jolokia-based metrics/v2 endpoint.
+            # Default is true.
+            #enabled: false
+
+            # Configure any of the settings listed at:
+            #   https://jolokia.org/reference/html/agents.html#war-agent-installation
+            #servlet-init-params: {
+            #    # Specify a custom security policy:
+            #    #  https://jolokia.org/reference/html/security.html
+            #    policyLocation: "file:///etc/puppetlabs/<service name>/jolokia-access.xml"
+            #}
+        }
+    }
+}

--- a/ezbake/config/docker/conf.d/pcp-broker.conf
+++ b/ezbake/config/docker/conf.d/pcp-broker.conf
@@ -1,0 +1,10 @@
+pcp-broker: {
+  controller-uris: [
+      "wss://"${ORCHESTRATOR}":8140/server"
+  ]
+  controller-whitelist: [
+      "http://puppetlabs.com/inventory_request",
+      "http://puppetlabs.com/rpc_blocking_request",
+      "http://puppetlabs.com/rpc_non_blocking_request"
+  ]
+}

--- a/ezbake/config/docker/conf.d/web-routes.conf
+++ b/ezbake/config/docker/conf.d/web-routes.conf
@@ -1,0 +1,9 @@
+web-router-service: {
+    "puppetlabs.pcp.broker.service/broker-service": {
+        "metrics": "/",
+        "v1": "/pcp",
+        "v2": "/pcp2"
+    }
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+    "puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice": "/metrics"
+}

--- a/ezbake/config/docker/conf.d/webserver.conf
+++ b/ezbake/config/docker/conf.d/webserver.conf
@@ -1,0 +1,16 @@
+webserver: {
+  default-server: true
+  ssl-host: 0.0.0.0
+  ssl-port: 8140
+  client-auth: "want"
+  ssl-cert: "/ssl/cert.pem"
+  ssl-key: "/ssl/key.pem"
+  ssl-ca-cert: "/ssl/ca.pem"
+  ssl-crl-path: "/ssl/crl.pem"
+  access-log-config: "/config/request-logging.xml"
+  ssl-protocols: [
+      "TLSv1",
+      "TLSv1.1",
+      "TLSv1.2"
+  ]
+}

--- a/ezbake/config/docker/logback.xml
+++ b/ezbake/config/docker/logback.xml
@@ -1,0 +1,19 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="puppetlabs.trapperkeeper.services.status.status-debug-logging" level="debug" />
+
+    <!-- only reports failures by default, to see successes change level to "info" -->
+    <logger name="puppetlabs.pcp.broker.pcp_access" level="error" />
+    <logger name="puppetlabs.pcp" level="info" />
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+

--- a/ezbake/config/docker/request-logging.xml
+++ b/ezbake/config/docker/request-logging.xml
@@ -1,0 +1,9 @@
+<configuration debug="false" scan="true">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+    </encoder>
+  </appender>
+
+  <appender-ref ref="STDOUT" />
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
                  [puppetlabs/i18n]]
 
   :plugins [[lein-parent "0.3.4"]
+            [puppetlabs/lein-ezbake "1.9.0"]
             [puppetlabs/i18n "0.8.0"]
             [lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
@@ -49,6 +50,9 @@
                                      :sign-releases false}]]
 
   :test-paths ["test/unit" "test/integration" "test/utils" "test-resources"]
+
+  :lein-ezbake {:config-dir "ezbake/config"
+                :vars {:docker {:ports [8140]}}}
 
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[http.async.client ~http-async-client-version]
@@ -70,6 +74,13 @@
                                       {:injections [(do
                                                      (require 'schema.core)
                                                      (schema.core/set-fn-validation! true))]}]
+             :uberjar {:aot [puppetlabs.pcp.broker.service
+                             puppetlabs.trapperkeeper.services.authorization.authorization-service
+                             puppetlabs.trapperkeeper.services.metrics.metrics-service
+                             puppetlabs.trapperkeeper.services.scheduler.scheduler-service
+                             puppetlabs.trapperkeeper.services.status.status-service
+                             puppetlabs.trapperkeeper.services.webrouting.webrouting-service
+                             puppetlabs.trapperkeeper.services.webserver.jetty9-service]}
              :unit [:test-base
                     {:test-paths ^:replace ["test/unit"]}]
              :integration [:test-base


### PR DESCRIPTION
This adds config to project.clj and the ezbake/config/docker directory
in order to build a docker image via `lein ezbake docker-build`. This
image contains only pcp-broker and accepts its config via environment
variables.