### PR TITLE
(PCP-862) Use disconnect rather than close

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.0.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.6.4"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -537,7 +537,8 @@
                         ;; 2 : remote address of connection
                         #(i18n/trs "Node with URI {0} already associated with connection {1} {2}."
                           (:uri %) (:commonname %) (:remoteaddress %)))
-             (websockets-client/close! (:websocket old-conn) 4000 (i18n/trs "Superseded.")))
+             (websockets-client/close! (:websocket old-conn) 4000 (i18n/trs "Superseded."))
+             (websockets-client/disconnect (:websocket old-conn)))
            (websockets-client/idle-timeout! ws (* 1000 60 15))
            (let [policy (.. ws getSession getPolicy)]
              ;; Support both v1 and v2 agents


### PR DESCRIPTION
This changes closing the pcp connection behavior to use disconnect in place of close, in hopes that disconnect will stop the connection more quickly and reduce the number of file descriptors opened by pcp at any given time.