### PR TITLE
(PCP-862) Remove `close!` call before disconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.3
+
+This is a maintenance release
+* Removes the `close!` call before disconnecting. Having both `close` and `disconnect` created a race condition where `close` could close the connection too quickly. Manual testing with a check to ensure the session was still open nullified any resource saving benefits of having the disconnect.
+
 ## 1.5.2
 
 This is a maintenance release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.2
+
+This is a maintenance release
+* [PCP-862](https://tickets.puppetlabs.com/browse/PCP-862) Adds `disconnect` call when ending a superseded session after `close!` in order to free resources more quickly
+
 ## 1.5.0
 
 This is a feature release

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -537,7 +537,6 @@
                         ;; 2 : remote address of connection
                         #(i18n/trs "Node with URI {0} already associated with connection {1} {2}."
                           (:uri %) (:commonname %) (:remoteaddress %)))
-             (websockets-client/close! (:websocket old-conn) 4000 (i18n/trs "Superseded."))
              (websockets-client/disconnect (:websocket old-conn)))
            (websockets-client/idle-timeout! ws (* 1000 60 15))
            (let [policy (.. ws getSession getPolicy)]

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -197,7 +197,7 @@
                                                          :version version)]
                  ;; NB(ale): client/connect checks associate_response for both clients
                  (let [close-websocket-msg1 (client/recv! first-client)]
-                   (is (= [4000 "Superseded."] close-websocket-msg1)))))))
+                   (is (= [1006 "Connection was closed abnormally (that is, with no close frame being sent)."] close-websocket-msg1)))))))
 
 (deftest second-association-same-connection-is-accepted-test
   (with-app-with-config app broker-services broker-config


### PR DESCRIPTION
This removes the `close!` call before disconnecting a superseded connection. It was originally left to preserve the code and reason in logging, but appeared to leave unused sockets open, consuming resources even when disconnect was called. Using just `disconnect` frees the resources, and we determined there was already sufficient logging of pxp-agents being superseded to lose the 'Superseded' message.
