### PR TITLE
(PCP-866) Allow status requests in test authorization config

### DIFF
--- a/test-resources/conf.d/authorization.conf
+++ b/test-resources/conf.d/authorization.conf
@@ -11,5 +11,15 @@ authorization: {
       allow-unauthenticated: true
       sort-order: 400
     },
+    {
+      name: "status service",
+        match-request {
+          method: get
+          type: path
+          path: "/status"
+        }
+      allow-unauthenticated: true
+      sort-order: 401
+    }
   ]
 }


### PR DESCRIPTION
4ed40af updated clj-parent to a version that includes
trapperkeeper-status 1.1.0, which now uses trapperkeeper-auth to guard
the status routes. That caused status requests to fail against
pcp-broker when running with the config in test-resources (as the
pxp-agent acceptance tests use).

We now include a rule in the authorization.conf that explicitly allows
unauthenticated access to the status endpoint.