### PR TITLE
(ORCH-2283) retry HTTP errors during WebSocket upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: clojure
+dist: xenial
 sudo: false
 lein: 2.8.1
 jdk:
-  - oraclejdk9
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 script:
   - lein $TEST_OPTIONS test
   - if [ "$TEST_OPTIONS" = "" ]; then ./ext/travisci/secscan.sh src clj "clojure.core/read-string"; fi

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "1.2.0"]
+                 [puppetlabs/pcp-client "1.2.1"]
 
                  [puppetlabs/i18n]]
 


### PR DESCRIPTION
Handles a condition where an HTTP exception occurring during a WebSocket
Upgrade should be retried. This commonly happens when pe-orchestration-services
is restarted.