### PR TITLE
(maint) Allow adjusting the idle timeout and lower its default

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -490,7 +490,7 @@
    Broker service is not running or if the client common name is not obtainable
    from its cert. Otherwise set the idle timeout of the WebSocket connection
    to 15 min."
-  [{:keys [max-connections] :as broker} codec ws]
+  [{:keys [max-connections idle-timeout] :as broker} codec ws]
   (time!
    (:on-connect (:metrics broker))
    (cond
@@ -538,7 +538,7 @@
                         #(i18n/trs "Node with URI {0} already associated with connection {1} {2}."
                           (:uri %) (:commonname %) (:remoteaddress %)))
              (websockets-client/disconnect (:websocket old-conn)))
-           (websockets-client/idle-timeout! ws (* 1000 60 15))
+           (websockets-client/idle-timeout! ws idle-timeout)
            (let [policy (.. ws getSession getPolicy)]
              ;; Support both v1 and v2 agents
              (.setMaxTextMessageSize policy (:max-message-size broker))
@@ -769,6 +769,7 @@
    :get-metrics-registry IFn
    :max-connections s/Int
    :max-message-size s/Int
+   :idle-timeout s/Int
    (s/optional-key :broker-name) s/Str})
 
 (s/defn init :- Broker
@@ -779,10 +780,12 @@
                 get-route
                 get-metrics-registry
                 max-connections
-                max-message-size]} options
+                max-message-size
+                idle-timeout]} options
         broker  {:broker-name         broker-name
                  :max-connections     max-connections
                  :max-message-size    max-message-size
+                 :idle-timeout        idle-timeout
                  :authorization-check authorization-check
                  :database            (atom (inventory/init-database))
                  :controllers         (atom {})

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -23,7 +23,7 @@
         (sl/maplog :info {:type :broker-init} (fn [_] (i18n/trs "Initializing broker service.")))
         (let [max-connections    (get-in-config [:pcp-broker :max-connections] 0)
               max-message-size   (get-in-config [:pcp-broker :max-message-size] (* 64 1024 1024))
-              idle-timeout       (get-in-config [:pcp-broker :idle-timeout] (* 1000 60 15))
+              idle-timeout       (get-in-config [:pcp-broker :idle-timeout] (* 1000 60 6))
               broker             (core/init {:add-websocket-handler (partial add-websocket-handler this)
                                              :authorization-check   authorization-check
                                              :get-metrics-registry  get-metrics-registry

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -23,11 +23,13 @@
         (sl/maplog :info {:type :broker-init} (fn [_] (i18n/trs "Initializing broker service.")))
         (let [max-connections    (get-in-config [:pcp-broker :max-connections] 0)
               max-message-size   (get-in-config [:pcp-broker :max-message-size] (* 64 1024 1024))
+              idle-timeout       (get-in-config [:pcp-broker :idle-timeout] (* 1000 60 15))
               broker             (core/init {:add-websocket-handler (partial add-websocket-handler this)
                                              :authorization-check   authorization-check
                                              :get-metrics-registry  get-metrics-registry
                                              :max-connections       max-connections
                                              :max-message-size      max-message-size
+                                             :idle-timeout          idle-timeout
                                              :get-route             (partial get-route this)})]
           (register-status "broker-service"
                            (status-core/get-artifact-version "puppetlabs" "pcp-broker")

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -48,6 +48,7 @@
    :authorization-check IFn
    :max-connections     s/Int
    :max-message-size    s/Int
+   :idle-timeout        s/Int
    :database            (s/atom BrokerDatabase)
    :controllers         (s/atom {p/Uri Connection})
    :should-stop         Object                              ;; Promise used to signal the inventory updates should stop

--- a/test/unit/puppetlabs/pcp/broker/shared_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/shared_test.clj
@@ -24,6 +24,7 @@
                 :controllers         (atom {})
                 :max-connections     0
                 :max-message-size    65536
+                :idle-timeout        360000
                 :should-stop         (promise)
                 :metrics             {}
                 :metrics-registry    metrics.core/default-registry


### PR DESCRIPTION
pcp-broker appears to have hang on to SSLContexts and connections longer than necessary in dynamic environments where agents frequently come and go. While idle-timeout is most likely not contributing significantly to that, it seems like a simple thing to lower and help in a small way.