### PR TITLE
(PCP-900) Close connections after CRL update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
                  [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-webserver-jetty9]
                  [puppetlabs/trapperkeeper-status]
+                 [puppetlabs/trapperkeeper-filesystem-watcher]
 
                  [puppetlabs/structured-logging]
                  [puppetlabs/ssl-utils]

--- a/test-resources/bootstrap.cfg
+++ b/test-resources/bootstrap.cfg
@@ -6,3 +6,4 @@ puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service

--- a/test/utils/puppetlabs/pcp/testutils/service.clj
+++ b/test/utils/puppetlabs/pcp/testutils/service.clj
@@ -3,6 +3,7 @@
             [puppetlabs.trapperkeeper.app :as tka]
             [puppetlabs.pcp.broker.service :refer [broker-service]]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
+            [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service :refer [filesystem-watch-service]]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :refer [metrics-service]]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
             [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service]]
@@ -42,7 +43,7 @@
 
 (def broker-services
   "The trapperkeeper services the broker needs"
-  [authorization-service broker-service jetty9-service webrouting-service metrics-service status-service scheduler-service])
+  [authorization-service broker-service jetty9-service webrouting-service metrics-service status-service scheduler-service filesystem-watch-service])
 
 (defn get-context
   [app svc]


### PR DESCRIPTION
tk-jetty9 will reload the SSLContextFactory for pcp-broker when changes
to the CRL occur. In doing so new connections will use the CRL updates.
However pcp-broker, by design, keeps connections open for long durations.
This can result in many different SSLContexts in the heap with different
versions of the CRL. Coupled with large CRLs this can take up a
significant portion of the heap (10-20%).

This brings in tk-filesystem-watcher as a dependency and, like
tk-jetty9, watches the CRL for updates. When it has changed the client
are disconnected fromt the server. This is under the assumption that the
clients will reconnect and the server will be able to use the new CRL.

Some caveats:

 - The SSLContextFactory is not guaranteed to have reloaded by the time
   the first agent reconnects. This might cause 2 CRL versions in memory,
   but should limit the number to 2.  Unfortunately, even though
   SSLContextFactory implements a Lifecycle listener pattern, reloads do
   not seem to trigger them (the code looks like only start and stop are
   implemented).

 - This could cause significant churn in large deployments.