### PR TITLE
(PCP-900) Throttle connection resets after crl is expired

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -94,6 +94,9 @@ connections in the `pcp-broker` section. These options are:
 * max-connections: The maximum number of clients that can connect to the
   broker. Defaults to 0, which is interpreted as unlimited.
 * max-message-size: The maximum message size, specified in bytes. Defaults to 64 MB. This value can be overriden and reduced to something smaller as desired.
+* idle-timeout: The time, in milliseconds, to wait for an idle connection before closing it. The default is 360,000 (6 minutes) which is 3 times the client's default ping interval. Changing this setting should be coordinated with changes to the client's ping interval.
+* crl-check-period: The time, in milliseconds, that pcp-broker will check to see if any connections in its inventory have been expired (currently, connections may be expired due to a CRL update). Default is 60,000 (1 minute).
+* expired-conn-throttle: The time, in milliseconds, to wait between closing each expired connection. Default is 30. For example, a broker with 1,000 expired connections closing these connections will be spread out across at least 30 seconds.
 ```
 pcp-broker: {
     controller-uris: ["wss://broker.example.com:8143/server", "wss://broker2.example.com:8143/server"],
@@ -101,5 +104,8 @@ pcp-broker: {
                            "http://puppetlabs.com/rpc_blocking_request"],
     controller-disconnection-graceperiod: "90s"
     max-connections: 10000
+    idle-timeout: 360000
+    crl-check-period: 60000
+    expired-conn-throttle: 30
 }
 ```

--- a/src/puppetlabs/pcp/broker/connection.clj
+++ b/src/puppetlabs/pcp/broker/connection.clj
@@ -22,7 +22,8 @@
 (s/defrecord Connection
              [websocket :- Websocket
               codec :- Codec
-              uri :- p/Uri]
+              uri :- p/Uri
+              expired :- s/Bool]
   ConnectionInterface
   (summarize [c] (-summarize c)))
 
@@ -35,12 +36,14 @@
   "Return the initial state for a websocket"
   [websocket :- Websocket
    codec :- Codec
-   uri :- p/Uri]
+   uri :- p/Uri
+   expired :- s/Bool]
   ;; NOTE(ale): the 'map->...' constructor comes from schema.core's defrecord
   (map->Connection
    {:websocket      websocket
     :codec          codec
-    :uri            uri}))
+    :uri            uri
+    :expired        expired}))
 
 (s/defn -summarize :- ConnectionLog
   [connection :- Connection]

--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -517,7 +517,7 @@
      :else
      ;; Generate an implicit association request and authorize association.
      (let [uri (ws->uri ws)
-           connection (connection/make-connection ws codec uri)
+           connection (connection/make-connection ws codec uri false)
            message (message/make-message
                      {:target "pcp:///server"
                       :sender uri
@@ -692,17 +692,26 @@
       :info {}
       (fn [_] (i18n/trs "Evicted all clients as there is no controller connection.")))))
 
-(defn restart-client-connections!
+(defn close-expired-connections!
   "Forces clients to reconnect because the broker's CRL is out of date"
   [broker]
-  (doseq [[_ client-connection] (:inventory @(:database broker))]
-    (websockets-client/close!
-      (:websocket client-connection)
-      1012 ;; code SERVER_RESTART, client *should* reconnect soon
-      (i18n/trs "CRL reloaded"))
-    (sl/maplog
-      :info {}
-      (fn [_] (i18n/trs "Evicted all clients because of CRL reload")))))
+  (let [inventory-snapshot (:inventory @(:database broker))
+        throttle-duration (:expired-conn-throttle broker)]
+    (sl/maplog :debug
+               {:count (count inventory-snapshot)}
+               #(i18n/trs "Checking the existing {0} connections for expired CRLs." (:count %)))
+    (doseq [[uri client-connection] inventory-snapshot]
+      (when (:expired client-connection)
+        (do
+          (sl/maplog :debug {:uri uri} #(i18n/trs "Closing expired connection for {0}." (:uri %)))
+          (Thread/sleep throttle-duration)
+          (websockets-client/close!
+            (:websocket client-connection)
+            1012 ;; code SERVER_RESTART, client *should* reconnect soon
+            (i18n/trs "CRL reloaded"))
+          (sl/maplog
+            :info {}
+            (fn [_] (i18n/trs "Evicted stale client connections because of CRL reload."))))))))
 
 (defn on-controller-connect!
   [broker controller-uri ws]
@@ -760,7 +769,7 @@
                ;; 0 : uri identifying connection
                ;; 1 : url to connect to
                #(i18n/trs "Connecting to {0} at {1}." (:pcpuri %) (:uri %)))
-    [pcp-uri (connection/make-connection client identity-codec pcp-uri)]))
+    [pcp-uri (connection/make-connection client identity-codec pcp-uri false)]))
 
 (s/defn initiate-controller-connections :- {p/Uri Connection}
   "Create PCP Clients for each controller URI"
@@ -772,6 +781,29 @@
   (into {} (pmap (partial start-client broker ssl-context
                           controller-whitelist controller-disconnection-ms)
                  controller-uris)))
+
+(s/defn start-crl-monitoring!
+  "Start periodic refreshing of connections using outdated crls"
+  [broker :- Broker]
+  (future
+    (let [should-stop (:should-stop broker)
+          check-interval (:crl-check-period broker)]
+      (loop []
+        (close-expired-connections! broker)
+        (if (nil? (deref should-stop check-interval nil))
+          (recur))))))
+
+(s/defn expire-ssl-connections*
+  [inventory :- shared/Inventory]
+  (sl/maplog :info
+             {:count (count inventory)}
+             #(i18n/trs "Expiring existing {0} connections due to CRL update." (:count %)))
+  (into {} (for [[k {:keys [websocket codec uri]}] inventory]
+             [k (connection/make-connection websocket codec uri true)])))
+
+(s/defn expire-ssl-connections
+  [broker :- Broker]
+  (swap! (:database broker) update :inventory expire-ssl-connections* ))
 
 (s/defn watch-crl
   [watcher :- (s/protocol watch/Watcher)
@@ -788,7 +820,7 @@
                        (= (.getCanonicalPath (:changed-path %))
                           crl-path))
                      events)
-           (restart-client-connections! broker)))))))
+           (expire-ssl-connections broker)))))))
 
 ;;
 ;; Broker service lifecycle, status service
@@ -802,6 +834,8 @@
    :max-connections s/Int
    :max-message-size s/Int
    :idle-timeout s/Int
+   :crl-check-period s/Int
+   :expired-conn-throttle s/Int
    (s/optional-key :broker-name) s/Str})
 
 (s/defn init :- Broker
@@ -813,19 +847,23 @@
                 get-metrics-registry
                 max-connections
                 max-message-size
-                idle-timeout]} options
-        broker  {:broker-name         broker-name
-                 :max-connections     max-connections
-                 :max-message-size    max-message-size
-                 :idle-timeout        idle-timeout
-                 :authorization-check authorization-check
-                 :database            (atom (inventory/init-database))
-                 :controllers         (atom {})
-                 :should-stop         (promise)
-                 :metrics             {}
-                 :metrics-registry    (get-metrics-registry)
-                 :state               (atom :starting)
-                 :handlers            (atom [])}
+                idle-timeout
+                crl-check-period
+                expired-conn-throttle]} options
+        broker  {:broker-name           broker-name
+                 :max-connections       max-connections
+                 :max-message-size      max-message-size
+                 :idle-timeout          idle-timeout
+                 :crl-check-period      crl-check-period
+                 :expired-conn-throttle expired-conn-throttle
+                 :authorization-check   authorization-check
+                 :database              (atom (inventory/init-database))
+                 :controllers           (atom {})
+                 :should-stop           (promise)
+                 :metrics               {}
+                 :metrics-registry      (get-metrics-registry)
+                 :state                 (atom :starting)
+                 :handlers              (atom [])}
         metrics (shared/build-and-register-metrics broker)
         broker  (assoc broker :metrics metrics)]
     (swap! (:handlers broker) conj
@@ -846,6 +884,7 @@
     (when (all-controllers-disconnected? broker)
       (stop-handlers broker)))
   (inventory/start-inventory-updates! broker)
+  (start-crl-monitoring! broker)
   (-> broker :state (reset! :running)))
 
 (s/defn stop

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -23,16 +23,20 @@
    :optional [FileSyncStorageService]}
   (init [this context]
         (sl/maplog :info {:type :broker-init} (fn [_] (i18n/trs "Initializing broker service.")))
-        (let [max-connections    (get-in-config [:pcp-broker :max-connections] 0)
-              max-message-size   (get-in-config [:pcp-broker :max-message-size] (* 64 1024 1024))
-              idle-timeout       (get-in-config [:pcp-broker :idle-timeout] (* 1000 60 6))
-              broker             (core/init {:add-websocket-handler (partial add-websocket-handler this)
-                                             :authorization-check   authorization-check
-                                             :get-metrics-registry  get-metrics-registry
-                                             :max-connections       max-connections
-                                             :max-message-size      max-message-size
-                                             :idle-timeout          idle-timeout
-                                             :get-route             (partial get-route this)})]
+        (let [max-connections       (get-in-config [:pcp-broker :max-connections] 0)
+              max-message-size      (get-in-config [:pcp-broker :max-message-size] (* 64 1024 1024))
+              idle-timeout          (get-in-config [:pcp-broker :idle-timeout] (* 1000 60 6))
+              expired-conn-throttle (get-in-config [:pcp-broker :expired-conn-throttle] 30)
+              crl-check-period      (get-in-config [:pcp-broker :crl-check-period] (* 1000 60))
+              broker                (core/init {:add-websocket-handler (partial add-websocket-handler this)
+                                                :authorization-check   authorization-check
+                                                :get-metrics-registry  get-metrics-registry
+                                                :max-connections       max-connections
+                                                :max-message-size      max-message-size
+                                                :idle-timeout          idle-timeout
+                                                :crl-check-period      crl-check-period
+                                                :expired-conn-throttle expired-conn-throttle
+                                                :get-route             (partial get-route this)})]
           (register-status "broker-service"
                            (status-core/get-artifact-version "puppetlabs" "pcp-broker")
                            1

--- a/src/puppetlabs/pcp/broker/shared.clj
+++ b/src/puppetlabs/pcp/broker/shared.clj
@@ -44,18 +44,20 @@
    :subscriptions      {p/Uri Subscription}})
 
 (def Broker
-  {:broker-name         (s/maybe s/Str)
-   :authorization-check IFn
-   :max-connections     s/Int
-   :max-message-size    s/Int
-   :idle-timeout        s/Int
-   :database            (s/atom BrokerDatabase)
-   :controllers         (s/atom {p/Uri Connection})
-   :should-stop         Object                              ;; Promise used to signal the inventory updates should stop
-   :metrics-registry    Object
-   :metrics             {s/Keyword Object}
-   :state               (s/atom BrokerState)
-   :handlers            (s/atom [ContextHandler])})
+  {:broker-name           (s/maybe s/Str)
+   :authorization-check   IFn
+   :max-connections       s/Int
+   :max-message-size      s/Int
+   :idle-timeout          s/Int
+   :crl-check-period      s/Int
+   :expired-conn-throttle s/Int
+   :database              (s/atom BrokerDatabase)
+   :controllers           (s/atom {p/Uri Connection})
+   :should-stop           Object                        ;; Promise used to signal the inventory updates should stop
+   :metrics-registry      Object
+   :metrics               {s/Keyword Object}
+   :state                 (s/atom BrokerState)
+   :handlers              (s/atom [ContextHandler])})
 
 (s/defn get-connection :- (s/maybe Connection)
   [broker :- Broker uri :- p/Uri]

--- a/test/integration/puppetlabs/pcp/broker/service_test.clj
+++ b/test/integration/puppetlabs/pcp/broker/service_test.clj
@@ -128,7 +128,12 @@
 
 (deftest connection-resets-on-crl-change
   (testing "broker closes connection when CRL file is changed"
-    (with-app-with-config app broker-services broker-config
+    (with-app-with-config
+      app
+      broker-services
+      (merge broker-config
+             {:pcp-broker {:expired-conn-throttle 1
+                           :crl-check-period 10}})
       (let [start (System/currentTimeMillis)
             timeout 10000
             should-disconnect-by (+ start (- timeout 1000))

--- a/test/unit/puppetlabs/pcp/broker/connection_test.clj
+++ b/test/unit/puppetlabs/pcp/broker/connection_test.clj
@@ -4,6 +4,7 @@
 
 (deftest make-connection-test
   (testing "It returns a map that matches represents a new socket"
-    (let [socket (make-connection :dummy-ws {:encode identity :decode identity} "pcp:///dummy-uri")]
+    (let [socket (make-connection :dummy-ws {:encode identity :decode identity} "pcp:///dummy-uri" false)]
       (is (= :dummy-ws (:websocket socket)))
-      (is (= nil (:endpoint socket))))))
+      (is (= nil (:endpoint socket)))
+      (is (= false (:expired socket))))))


### PR DESCRIPTION
Previously, in 44ce091, we began closing all connections after a CRL
update to prevent stale SSLContexts from being held in memory. However,
the previous change dropped all connections in quick succession and
there was some concern that it could cause undo spikes in load from a
thundering herd of reconnection attempts.

This patch creates a background thread (the same as how we send inventory
updates) that every X milliseconds tries to close any Connections in the
inventory marked expired. It also throttles the attempt to close all
connections by sleeping Y milliseconds between each Connection it
closes. X and Y are configurable by the new config values
`crl-check-period` and `expired-conn-throttle` respectively. The default
to 60 seconds between CRL checks and 30 milliseconds between individual
Connection closes.

This should give a small but meaningful window for multiple CRL updates
to coalesce and cause connection resets for a 1000-connections-per-broker
deployment to take around 1 minute. Note, the `crl-check-period` is waited
for after/in-additon-to whatever time it takes to close any existing
expired connections.

Previously, the file-system watcher which used to trigger the connection
closing on CRL update now only marks existing Connections as expired for
the background thread to purge in its configured time.