### PR TITLE
(maint) Coerce URI to str before passing to sl/maplog

### DIFF
--- a/src/puppetlabs/pcp/broker/core.clj
+++ b/src/puppetlabs/pcp/broker/core.clj
@@ -703,7 +703,7 @@
     (doseq [[uri client-connection] inventory-snapshot]
       (when (:expired client-connection)
         (do
-          (sl/maplog :debug {:uri uri} #(i18n/trs "Closing expired connection for {0}." (:uri %)))
+          (sl/maplog :debug {:uri (str uri)} #(i18n/trs "Closing expired connection for {0}." (:uri %)))
           (Thread/sleep throttle-duration)
           (websockets-client/close!
             (:websocket client-connection)


### PR DESCRIPTION
The structured logging macro `maplog` will attempt to serialize a
URI, however we need its string representation for our logging. Coerce,
URIs to strings when closing connections due to CRL updates.