### PR TITLE
(PE-30041) Add rpc_*_requests to default allowed message types

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -86,7 +86,7 @@ connections in the `pcp-broker` section. These options are:
 * controller-uris: An array of Websocket URIs to which the broker will attempt
   to establish outbound connections.
 * controller-allowlist: An array of message types the broker will accept from
-  connected controllers. Defaults to accepting only inventory requests.
+  connected controllers. Defaults to accepting  inventory requests, blocking and non blocking rpc requests.
 * controller-disconnection-graceperiod: The number of milliseconds after losing
   connectivity to all configured controllers that the broker will wait before
   dropping all connected clients (to allow them to redistribute to other

--- a/src/puppetlabs/pcp/broker/service.clj
+++ b/src/puppetlabs/pcp/broker/service.clj
@@ -51,7 +51,9 @@
                                                ks/parse-interval
                                                t/in-millis)
                controller-allowlist (set (get-in-config [:pcp-broker :controller-allowlist]
-                                                        ["http://puppetlabs.com/inventory_request"]))
+                                                        ["http://puppetlabs.com/inventory_request"
+                                                         "http://puppetlabs.com/rpc_blocking_request"
+                                                         "http://puppetlabs.com/rpc_non_blocking_request"]))
                broker (:broker context)
                server-context (some-> (get-service this :WebserverService)
                                       service-context


### PR DESCRIPTION
When the controller-whitelist setting was moved to controller-allowlist it brought up a discussion around what reasonable defaults to expect for the setting. This commit updates the defaults to include the rpc messages where previously they were not included.