### PR TITLE
(maint) Fix lein uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,8 @@
                                       {:injections [(do
                                                      (require 'schema.core)
                                                      (schema.core/set-fn-validation! true))]}]
-             :uberjar {:aot [puppetlabs.pcp.broker.service
+             :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]
+                       :aot [puppetlabs.pcp.broker.service
                              puppetlabs.trapperkeeper.services.authorization.authorization-service
                              puppetlabs.trapperkeeper.services.metrics.metrics-service
                              puppetlabs.trapperkeeper.services.scheduler.scheduler-service


### PR DESCRIPTION
This commit adds a Bouncycastle dependency to the uberjar profile that
was missed when Bouncycastle usage was re-factored to support a
FIPS/non-FIPS split. The dependency allows `lein uberjar` to complete
instead of failing during AOT compilation.