### PR TITLE
(maint) update clj-parent to 4.8.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.28"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.8.3"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This brings in a new version of http-client that conditionally
allows auth headers when being redirected.