### PR TITLE
(PE-34654) update clj-parent, pcp-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.8.0
+This is a maintenance release
+* update clj-parent to 5.2.9
+* update pcp-client to 1.4.0
+
 ## 1.6.5
 This is a maintenance release
 * update clj-parent to 4.9.1

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def http-async-client-version "1.3.0")
 
-(defproject puppetlabs/pcp-broker "1.7.6-SNAPSHOT"
+(defproject puppetlabs/pcp-broker "1.8.0-SNAPSHOT"
   :description "PCP fabric messaging broker"
   :url "https://github.com/puppetlabs/pcp-broker"
   :license {:name "Apache License, Version 2.0"
@@ -13,7 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.9.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.9"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -33,7 +33,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "1.3.4"]
+                 [puppetlabs/pcp-client "1.4.0"]
 
                  [puppetlabs/i18n]]
 


### PR DESCRIPTION
This updates clj-parent to 5.2.9, which is now managing `stylefruits/gniazdo`. The dependency is part of pcp-client, which, as of 1.4.0,  is using the version determined by clj-parent.

This also prepares for a new release.