### PR TITLE
(maint) handle connection exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+* ensure connection attempts that throw exceptions are correctly logged.
+* add additional logging to connection setup to help diagnose issues
+* update pcp-client for schema fixes
+
 ## 2.0.0
 
 This a major breaking release

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  ;; try+/throw+
                  [slingshot]
 
-                 [puppetlabs/pcp-client "2.0.0"]
+                 [puppetlabs/pcp-client "2.0.1"]
                  [puppetlabs/i18n]]
 
   :plugins [[lein-parent "0.3.7"]


### PR DESCRIPTION
This adds some exception handling to the connection setup to allow exceptions to be logged.  Prior to this change, an exception would stop the broker from correctly starting.

This also adds some additional logging to help diagnose issues.